### PR TITLE
feat(records): replace muscle mass with skeletal muscle and add total muscle fields to detailed history

### DIFF
--- a/backend/app/routers/records.py
+++ b/backend/app/routers/records.py
@@ -94,7 +94,8 @@ def get_summary(
             date=r.date,
             weight=r.weight,
             body_fat_pct=r.body_fat_pct,
-            muscle_mass=r.muscle_mass
+            muscle_mass=r.muscle_mass,
+            skeletal_muscle_mass=r.skeletal_muscle_mass
         ) for r in records
     ]
     
@@ -102,6 +103,7 @@ def get_summary(
     weight_change = last.weight - first.weight
     body_fat_change = last.body_fat_pct - first.body_fat_pct
     muscle_mass_change = last.muscle_mass - first.muscle_mass
+    skeletal_muscle_mass_change = last.skeletal_muscle_mass - first.skeletal_muscle_mass
     
     return DashboardSummary(
         total_records=total_records,
@@ -116,6 +118,9 @@ def get_summary(
         starting_muscle_mass=first.muscle_mass,
         current_muscle_mass=last.muscle_mass,
         muscle_mass_change=round(muscle_mass_change, 2),
+        starting_skeletal_muscle_mass=first.skeletal_muscle_mass,
+        current_skeletal_muscle_mass=last.skeletal_muscle_mass,
+        skeletal_muscle_mass_change=round(skeletal_muscle_mass_change, 2),
         weight_history=weight_history
     )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -176,6 +176,7 @@ class WeightHistoryPoint(BaseModel):
     weight: float
     body_fat_pct: float
     muscle_mass: float
+    skeletal_muscle_mass: float
 
 class DashboardSummary(BaseModel):
     total_records: int
@@ -194,6 +195,10 @@ class DashboardSummary(BaseModel):
     starting_muscle_mass: float | None = None
     current_muscle_mass: float | None = None
     muscle_mass_change: float | None = None
+
+    starting_skeletal_muscle_mass: float | None = None
+    current_skeletal_muscle_mass: float | None = None
+    skeletal_muscle_mass_change: float | None = None
 
     weight_history: List[WeightHistoryPoint]
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -218,6 +218,22 @@ def test_records_upload_and_summary(client: TestClient):
     expected_change = round(last_record_weight - 121.5, 2)
     assert summary["weight_change"] == expected_change
 
+    # Check skeletal muscle mass summary
+    assert "starting_skeletal_muscle_mass" in summary
+    assert "current_skeletal_muscle_mass" in summary
+    assert "skeletal_muscle_mass_change" in summary
+    
+    first_record_smm = records[0]["skeletal_muscle_mass"]
+    last_record_smm = records[-1]["skeletal_muscle_mass"]
+    expected_smm_change = round(last_record_smm - first_record_smm, 2)
+    
+    assert summary["starting_skeletal_muscle_mass"] == first_record_smm
+    assert summary["current_skeletal_muscle_mass"] == last_record_smm
+    assert summary["skeletal_muscle_mass_change"] == expected_smm_change
+    
+    assert "skeletal_muscle_mass" in summary["weight_history"][0]
+    assert summary["weight_history"][0]["skeletal_muscle_mass"] == first_record_smm
+
 
 def test_records_deletion(client: TestClient):
     # 1. Register and login User A

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,7 @@ export interface WeightHistoryPoint {
   weight: number;
   body_fat_pct: number;
   muscle_mass: number;
+  skeletal_muscle_mass: number;
 }
 
 export interface DashboardSummary {
@@ -35,6 +36,9 @@ export interface DashboardSummary {
   starting_muscle_mass: number | null;
   current_muscle_mass: number | null;
   muscle_mass_change: number | null;
+  starting_skeletal_muscle_mass: number | null;
+  current_skeletal_muscle_mass: number | null;
+  skeletal_muscle_mass_change: number | null;
   weight_history: WeightHistoryPoint[];
 }
 

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -207,15 +207,15 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
           </div>
         </div>
 
-        {/* Card: Muscle Mass */}
+        {/* Card: Skeletal Muscle */}
         <div className="bg-card border border-border rounded-xl p-5 shadow-xs flex items-start justify-between">
           <div className="space-y-2">
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Muscle Mass</p>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Skeletal Muscle</p>
             <div className="flex items-baseline gap-2">
-              <h3 className="text-3xl font-bold">{summary?.current_muscle_mass} <span className="text-sm font-normal text-muted-foreground">kg</span></h3>
-              {formatChange(summary!.muscle_mass_change, ' kg', false)}
+              <h3 className="text-3xl font-bold">{summary?.current_skeletal_muscle_mass} <span className="text-sm font-normal text-muted-foreground">kg</span></h3>
+              {formatChange(summary!.skeletal_muscle_mass_change, ' kg', false)}
             </div>
-            <p className="text-xs text-muted-foreground">Started at {summary?.starting_muscle_mass} kg</p>
+            <p className="text-xs text-muted-foreground">Started at {summary?.starting_skeletal_muscle_mass} kg</p>
           </div>
           <div className="p-3 bg-emerald-500/10 text-emerald-500 dark:text-emerald-400 rounded-lg">
             <Dumbbell className="h-5 w-5" />
@@ -269,7 +269,7 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
               }`}
             >
               <div className={`h-2.5 w-2.5 rounded-full bg-emerald-500 ${showMuscle ? 'scale-100' : 'scale-50 opacity-40'} transition-transform`} />
-              <span>Muscle Mass (kg)</span>
+              <span>Skeletal Muscle (kg)</span>
             </button>
           </div>
         </div>
@@ -350,9 +350,9 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
 
                 {showMuscle && (
                   <Line
-                    name="Muscle Mass (kg)"
+                    name="Skeletal Muscle (kg)"
                     type="monotone"
-                    dataKey="muscle_mass"
+                    dataKey="skeletal_muscle_mass"
                     stroke="#10b981" // Emerald
                     strokeWidth={3}
                     dot={{ r: 3, strokeWidth: 1 }}

--- a/frontend/src/views/History.tsx
+++ b/frontend/src/views/History.tsx
@@ -293,10 +293,10 @@ export default function History() {
                     Body Fat (%) {renderSortIcon('body_fat_pct')}
                   </th>
                   <th 
-                    onClick={() => handleSort('muscle_mass')}
+                    onClick={() => handleSort('skeletal_muscle_mass')}
                     className="px-6 py-4 cursor-pointer hover:bg-muted/80 transition-colors select-none"
                   >
-                    Muscle Mass (kg) {renderSortIcon('muscle_mass')}
+                    Skeletal Muscle (kg) {renderSortIcon('skeletal_muscle_mass')}
                   </th>
                   <th 
                     onClick={() => handleSort('body_score')}
@@ -339,7 +339,7 @@ export default function History() {
                     <td className="px-6 py-4 whitespace-nowrap">{record.weight.toFixed(1)} kg</td>
                     <td className="px-6 py-4 whitespace-nowrap">{record.bmi.toFixed(1)}</td>
                     <td className="px-6 py-4 whitespace-nowrap">{record.body_fat_pct.toFixed(1)}%</td>
-                    <td className="px-6 py-4 whitespace-nowrap">{record.muscle_mass.toFixed(1)} kg</td>
+                    <td className="px-6 py-4 whitespace-nowrap">{record.skeletal_muscle_mass.toFixed(1)} kg</td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold ${
                         record.body_score >= 80 
@@ -436,8 +436,8 @@ export default function History() {
                   <div className="mx-auto h-7 w-7 rounded-lg bg-emerald-500/10 text-emerald-500 flex items-center justify-center">
                     <Dumbbell className="h-4 w-4" />
                   </div>
-                  <p className="text-xs text-muted-foreground font-semibold">Muscle</p>
-                  <p className="text-lg font-bold">{selectedRecord.muscle_mass.toFixed(1)} kg</p>
+                  <p className="text-xs text-muted-foreground font-semibold">Skeletal Muscle</p>
+                  <p className="text-lg font-bold">{selectedRecord.skeletal_muscle_mass.toFixed(1)} kg</p>
                 </div>
               </div>
 
@@ -511,11 +511,11 @@ export default function History() {
                 </div>
               </div>
 
-              {/* Cardiovascular & Skeletal */}
+              {/* Cardiovascular & Musculoskeletal */}
               <div className="bg-card border border-border rounded-xl p-5 space-y-4">
                 <h4 className="text-sm font-bold text-foreground border-b border-border pb-2 flex items-center gap-2">
                   <Heart className="h-4 w-4 text-rose-500" />
-                  <span>Cardiorespiratory & Skeletal</span>
+                  <span>Cardiorespiratory & Musculoskeletal</span>
                 </h4>
                 
                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-y-4 gap-x-6">
@@ -542,6 +542,14 @@ export default function History() {
                   <div>
                     <span className="block text-xs text-muted-foreground">SMI (Skeletal Muscle Index)</span>
                     <span className="text-sm font-semibold">{selectedRecord.smi || '-'}</span>
+                  </div>
+                  <div>
+                    <span className="block text-xs text-muted-foreground">Muscle Rate %</span>
+                    <span className="text-sm font-semibold">{selectedRecord.muscle_rate_pct.toFixed(1)}%</span>
+                  </div>
+                  <div>
+                    <span className="block text-xs text-muted-foreground">Total Muscle Mass</span>
+                    <span className="text-sm font-semibold">{selectedRecord.muscle_mass.toFixed(1)} kg</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Resolves #9. Updates frontend and backend summary endpoint to display and track Skeletal Muscle instead of the generic Muscle Mass metric, and adds Total Muscle Mass and Muscle Rate % to the Cardiorespiratory & Musculoskeletal section in Detailed History.