### PR TITLE
feat(dashboard): add unit toggles to body fat and muscle cards and graphs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -3,3 +3,5 @@
 - **GitHub PR Workflow Only**: All changes must be proposed via GitHub Pull Requests. Direct pushes to the `main` branch are strictly forbidden. Always create a feature branch, push the branch, and create a pull request.
 
 - **Database Migrations Required**: Any changes to the database schema must include corresponding Alembic migration scripts. The application must run these migrations automatically on startup. Direct/manual changes to production databases are strictly forbidden.
+
+- **Python Management via UV**: This project uses `uv` for Python environment and dependency management. Always run Python/pip related commands, tests, database migrations, and scripts using `uv` (e.g., `uv run`, `uv pip`, etc.).

--- a/backend/app/routers/records.py
+++ b/backend/app/routers/records.py
@@ -94,16 +94,20 @@ def get_summary(
             date=r.date,
             weight=r.weight,
             body_fat_pct=r.body_fat_pct,
+            body_fat_mass=r.fat_mass,
             muscle_mass=r.muscle_mass,
-            skeletal_muscle_mass=r.skeletal_muscle_mass
+            skeletal_muscle_mass=r.skeletal_muscle_mass,
+            skeletal_muscle_mass_pct=r.skeletal_muscle_mass_pct
         ) for r in records
     ]
     
     # Calculate differences
     weight_change = last.weight - first.weight
     body_fat_change = last.body_fat_pct - first.body_fat_pct
+    body_fat_mass_change = last.fat_mass - first.fat_mass
     muscle_mass_change = last.muscle_mass - first.muscle_mass
     skeletal_muscle_mass_change = last.skeletal_muscle_mass - first.skeletal_muscle_mass
+    skeletal_muscle_mass_pct_change = last.skeletal_muscle_mass_pct - first.skeletal_muscle_mass_pct
     
     return DashboardSummary(
         total_records=total_records,
@@ -115,12 +119,18 @@ def get_summary(
         starting_body_fat=first.body_fat_pct,
         current_body_fat=last.body_fat_pct,
         body_fat_change=round(body_fat_change, 2),
+        starting_body_fat_mass=first.fat_mass,
+        current_body_fat_mass=last.fat_mass,
+        body_fat_mass_change=round(body_fat_mass_change, 2),
         starting_muscle_mass=first.muscle_mass,
         current_muscle_mass=last.muscle_mass,
         muscle_mass_change=round(muscle_mass_change, 2),
         starting_skeletal_muscle_mass=first.skeletal_muscle_mass,
         current_skeletal_muscle_mass=last.skeletal_muscle_mass,
         skeletal_muscle_mass_change=round(skeletal_muscle_mass_change, 2),
+        starting_skeletal_muscle_mass_pct=first.skeletal_muscle_mass_pct,
+        current_skeletal_muscle_mass_pct=last.skeletal_muscle_mass_pct,
+        skeletal_muscle_mass_pct_change=round(skeletal_muscle_mass_pct_change, 2),
         weight_history=weight_history
     )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -175,8 +175,10 @@ class WeightHistoryPoint(BaseModel):
     date: datetime
     weight: float
     body_fat_pct: float
+    body_fat_mass: float
     muscle_mass: float
     skeletal_muscle_mass: float
+    skeletal_muscle_mass_pct: float
 
 class DashboardSummary(BaseModel):
     total_records: int
@@ -192,6 +194,10 @@ class DashboardSummary(BaseModel):
     current_body_fat: float | None = None
     body_fat_change: float | None = None
     
+    starting_body_fat_mass: float | None = None
+    current_body_fat_mass: float | None = None
+    body_fat_mass_change: float | None = None
+
     starting_muscle_mass: float | None = None
     current_muscle_mass: float | None = None
     muscle_mass_change: float | None = None
@@ -199,6 +205,10 @@ class DashboardSummary(BaseModel):
     starting_skeletal_muscle_mass: float | None = None
     current_skeletal_muscle_mass: float | None = None
     skeletal_muscle_mass_change: float | None = None
+
+    starting_skeletal_muscle_mass_pct: float | None = None
+    current_skeletal_muscle_mass_pct: float | None = None
+    skeletal_muscle_mass_pct_change: float | None = None
 
     weight_history: List[WeightHistoryPoint]
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -234,6 +234,36 @@ def test_records_upload_and_summary(client: TestClient):
     assert "skeletal_muscle_mass" in summary["weight_history"][0]
     assert summary["weight_history"][0]["skeletal_muscle_mass"] == first_record_smm
 
+    # Check new body fat mass fields
+    assert "starting_body_fat_mass" in summary
+    assert "current_body_fat_mass" in summary
+    assert "body_fat_mass_change" in summary
+    
+    first_record_bfm = records[0]["fat_mass"]
+    last_record_bfm = records[-1]["fat_mass"]
+    expected_bfm_change = round(last_record_bfm - first_record_bfm, 2)
+    
+    assert summary["starting_body_fat_mass"] == first_record_bfm
+    assert summary["current_body_fat_mass"] == last_record_bfm
+    assert summary["body_fat_mass_change"] == expected_bfm_change
+    assert "body_fat_mass" in summary["weight_history"][0]
+    assert summary["weight_history"][0]["body_fat_mass"] == first_record_bfm
+
+    # Check new skeletal muscle percentage fields
+    assert "starting_skeletal_muscle_mass_pct" in summary
+    assert "current_skeletal_muscle_mass_pct" in summary
+    assert "skeletal_muscle_mass_pct_change" in summary
+    
+    first_record_smmp = records[0]["skeletal_muscle_mass_pct"]
+    last_record_smmp = records[-1]["skeletal_muscle_mass_pct"]
+    expected_smmp_change = round(last_record_smmp - first_record_smmp, 2)
+    
+    assert summary["starting_skeletal_muscle_mass_pct"] == first_record_smmp
+    assert summary["current_skeletal_muscle_mass_pct"] == last_record_smmp
+    assert summary["skeletal_muscle_mass_pct_change"] == expected_smmp_change
+    assert "skeletal_muscle_mass_pct" in summary["weight_history"][0]
+    assert summary["weight_history"][0]["skeletal_muscle_mass_pct"] == first_record_smmp
+
 
 def test_records_deletion(client: TestClient):
     # 1. Register and login User A

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,8 +19,10 @@ export interface WeightHistoryPoint {
   date: string;
   weight: number;
   body_fat_pct: number;
+  body_fat_mass: number;
   muscle_mass: number;
   skeletal_muscle_mass: number;
+  skeletal_muscle_mass_pct: number;
 }
 
 export interface DashboardSummary {
@@ -33,12 +35,18 @@ export interface DashboardSummary {
   starting_body_fat: number | null;
   current_body_fat: number | null;
   body_fat_change: number | null;
+  starting_body_fat_mass: number | null;
+  current_body_fat_mass: number | null;
+  body_fat_mass_change: number | null;
   starting_muscle_mass: number | null;
   current_muscle_mass: number | null;
   muscle_mass_change: number | null;
   starting_skeletal_muscle_mass: number | null;
   current_skeletal_muscle_mass: number | null;
   skeletal_muscle_mass_change: number | null;
+  starting_skeletal_muscle_mass_pct: number | null;
+  current_skeletal_muscle_mass_pct: number | null;
+  skeletal_muscle_mass_pct_change: number | null;
   weight_history: WeightHistoryPoint[];
 }
 

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -36,6 +36,24 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
   const [showBodyFat, setShowBodyFat] = useState(false);
   const [showMuscle, setShowMuscle] = useState(false);
 
+  // States for unit toggling on cards & graphs
+  const [bodyFatUnit, setBodyFatUnit] = useState<'pct' | 'kg'>(() => {
+    return (localStorage.getItem('fitdays_body_fat_unit') as 'pct' | 'kg') || 'pct';
+  });
+  const [muscleUnit, setMuscleUnit] = useState<'kg' | 'pct'>(() => {
+    return (localStorage.getItem('fitdays_muscle_unit') as 'kg' | 'pct') || 'kg';
+  });
+
+  const handleBodyFatUnitChange = (unit: 'pct' | 'kg') => {
+    setBodyFatUnit(unit);
+    localStorage.setItem('fitdays_body_fat_unit', unit);
+  };
+
+  const handleMuscleUnitChange = (unit: 'kg' | 'pct') => {
+    setMuscleUnit(unit);
+    localStorage.setItem('fitdays_muscle_unit', unit);
+  };
+
   useEffect(() => {
     const fetchSummary = async () => {
       try {
@@ -194,30 +212,110 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
 
         {/* Card: Body Fat */}
         <div className="bg-card border border-border rounded-xl p-5 shadow-xs flex items-start justify-between">
-          <div className="space-y-2">
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Body Fat</p>
-            <div className="flex items-baseline gap-2">
-              <h3 className="text-3xl font-bold">{summary?.current_body_fat} <span className="text-sm font-normal text-muted-foreground">%</span></h3>
-              {formatChange(summary!.body_fat_change, '%', true)}
+          <div className="space-y-2 flex-1 mr-4">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Body Fat</p>
+              <div className="flex bg-muted p-0.5 rounded-md border border-border text-[10px]">
+                <button
+                  onClick={() => handleBodyFatUnitChange('pct')}
+                  className={`px-2 py-0.5 rounded-sm font-semibold transition-all cursor-pointer ${
+                    bodyFatUnit === 'pct'
+                      ? 'bg-card text-foreground shadow-xs font-bold'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  %
+                </button>
+                <button
+                  onClick={() => handleBodyFatUnitChange('kg')}
+                  className={`px-2 py-0.5 rounded-sm font-semibold transition-all cursor-pointer ${
+                    bodyFatUnit === 'kg'
+                      ? 'bg-card text-foreground shadow-xs font-bold'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  kg
+                </button>
+              </div>
             </div>
-            <p className="text-xs text-muted-foreground">Started at {summary?.starting_body_fat}%</p>
+            <div className="flex items-baseline gap-2">
+              <h3 className="text-3xl font-bold">
+                {bodyFatUnit === 'pct' ? (
+                  <>
+                    {summary?.current_body_fat}{' '}
+                    <span className="text-sm font-normal text-muted-foreground">%</span>
+                  </>
+                ) : (
+                  <>
+                    {summary?.current_body_fat_mass}{' '}
+                    <span className="text-sm font-normal text-muted-foreground">kg</span>
+                  </>
+                )}
+              </h3>
+              {bodyFatUnit === 'pct'
+                ? formatChange(summary!.body_fat_change, '%', true)
+                : formatChange(summary!.body_fat_mass_change, ' kg', true)}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Started at {bodyFatUnit === 'pct' ? `${summary?.starting_body_fat}%` : `${summary?.starting_body_fat_mass} kg`}
+            </p>
           </div>
-          <div className="p-3 bg-rose-500/10 text-rose-500 dark:text-rose-400 rounded-lg">
+          <div className="p-3 bg-rose-500/10 text-rose-500 dark:text-rose-400 rounded-lg shrink-0">
             <Activity className="h-5 w-5" />
           </div>
         </div>
 
         {/* Card: Skeletal Muscle */}
         <div className="bg-card border border-border rounded-xl p-5 shadow-xs flex items-start justify-between">
-          <div className="space-y-2">
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Skeletal Muscle</p>
-            <div className="flex items-baseline gap-2">
-              <h3 className="text-3xl font-bold">{summary?.current_skeletal_muscle_mass} <span className="text-sm font-normal text-muted-foreground">kg</span></h3>
-              {formatChange(summary!.skeletal_muscle_mass_change, ' kg', false)}
+          <div className="space-y-2 flex-1 mr-4">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Skeletal Muscle</p>
+              <div className="flex bg-muted p-0.5 rounded-md border border-border text-[10px]">
+                <button
+                  onClick={() => handleMuscleUnitChange('pct')}
+                  className={`px-2 py-0.5 rounded-sm font-semibold transition-all cursor-pointer ${
+                    muscleUnit === 'pct'
+                      ? 'bg-card text-foreground shadow-xs font-bold'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  %
+                </button>
+                <button
+                  onClick={() => handleMuscleUnitChange('kg')}
+                  className={`px-2 py-0.5 rounded-sm font-semibold transition-all cursor-pointer ${
+                    muscleUnit === 'kg'
+                      ? 'bg-card text-foreground shadow-xs font-bold'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  kg
+                </button>
+              </div>
             </div>
-            <p className="text-xs text-muted-foreground">Started at {summary?.starting_skeletal_muscle_mass} kg</p>
+            <div className="flex items-baseline gap-2">
+              <h3 className="text-3xl font-bold">
+                {muscleUnit === 'kg' ? (
+                  <>
+                    {summary?.current_skeletal_muscle_mass}{' '}
+                    <span className="text-sm font-normal text-muted-foreground">kg</span>
+                  </>
+                ) : (
+                  <>
+                    {summary?.current_skeletal_muscle_mass_pct}{' '}
+                    <span className="text-sm font-normal text-muted-foreground">%</span>
+                  </>
+                )}
+              </h3>
+              {muscleUnit === 'kg'
+                ? formatChange(summary!.skeletal_muscle_mass_change, ' kg', false)
+                : formatChange(summary!.skeletal_muscle_mass_pct_change, '%', false)}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Started at {muscleUnit === 'kg' ? `${summary?.starting_skeletal_muscle_mass} kg` : `${summary?.starting_skeletal_muscle_mass_pct}%`}
+            </p>
           </div>
-          <div className="p-3 bg-emerald-500/10 text-emerald-500 dark:text-emerald-400 rounded-lg">
+          <div className="p-3 bg-emerald-500/10 text-emerald-500 dark:text-emerald-400 rounded-lg shrink-0">
             <Dumbbell className="h-5 w-5" />
           </div>
         </div>
@@ -257,7 +355,7 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
               }`}
             >
               <div className={`h-2.5 w-2.5 rounded-full bg-rose-500 ${showBodyFat ? 'scale-100' : 'scale-50 opacity-40'} transition-transform`} />
-              <span>Body Fat (%)</span>
+              <span>Body Fat ({bodyFatUnit === 'pct' ? '%' : 'kg'})</span>
             </button>
             
             <button
@@ -269,7 +367,7 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
               }`}
             >
               <div className={`h-2.5 w-2.5 rounded-full bg-emerald-500 ${showMuscle ? 'scale-100' : 'scale-50 opacity-40'} transition-transform`} />
-              <span>Skeletal Muscle (kg)</span>
+              <span>Skeletal Muscle ({muscleUnit === 'kg' ? 'kg' : '%'})</span>
             </button>
           </div>
         </div>
@@ -305,6 +403,13 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
                 />
                 
                 <Tooltip
+                  formatter={(value: any, name?: any) => {
+                    const valNum = typeof value === 'number' ? value.toFixed(1) : value;
+                    const nameStr = name || '';
+                    if (nameStr.includes('%')) return [`${valNum}%`, nameStr];
+                    if (nameStr.includes('kg')) return [`${valNum} kg`, nameStr];
+                    return [valNum, nameStr];
+                  }}
                   contentStyle={{
                     backgroundColor: 'var(--color-card)',
                     borderColor: 'var(--color-border)',
@@ -338,9 +443,9 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
 
                 {showBodyFat && (
                   <Line
-                    name="Body Fat (%)"
+                    name={`Body Fat (${bodyFatUnit === 'pct' ? '%' : 'kg'})`}
                     type="monotone"
-                    dataKey="body_fat_pct"
+                    dataKey={bodyFatUnit === 'pct' ? 'body_fat_pct' : 'body_fat_mass'}
                     stroke="#f43f5e" // Rose
                     strokeWidth={3}
                     dot={{ r: 3, strokeWidth: 1 }}
@@ -350,9 +455,9 @@ export default function Dashboard({ onNavigateToImport }: DashboardProps) {
 
                 {showMuscle && (
                   <Line
-                    name="Skeletal Muscle (kg)"
+                    name={`Skeletal Muscle (${muscleUnit === 'kg' ? 'kg' : '%'})`}
                     type="monotone"
-                    dataKey="skeletal_muscle_mass"
+                    dataKey={muscleUnit === 'kg' ? 'skeletal_muscle_mass' : 'skeletal_muscle_mass_pct'}
                     stroke="#10b981" // Emerald
                     strokeWidth={3}
                     dot={{ r: 3, strokeWidth: 1 }}


### PR DESCRIPTION
## Description
This PR resolves issue #11 by introducing unit toggles (`%` vs `kg`) to the **Body Fat** and **Skeletal Muscle** cards on the Progress Dashboard. 

### Key Changes
- **Backend / API**:
  - Extended the `DashboardSummary` response and `WeightHistoryPoint` schemas to include both representations (`body_fat_mass` in kg, `skeletal_muscle_mass_pct` in %).
  - Populated these fields dynamically in the `/summary` router using existing DB columns (`fat_mass` and `skeletal_muscle_mass_pct`).
  - Added backend integration assertions to test suite.
- **Frontend / UI**:
  - Implemented styled, compact segmented controls on the Body Fat and Skeletal Muscle cards with consistent `% | kg` order.
  - Dynamically updated card displays, delta badges, and history comparison graph lines.
  - Configured `localStorage` persistence for metric unit preferences.
  - Formatted tooltip values to match units dynamically.
- **Workspace Configuration**:
  - Appended Python management rule via `uv` tool in `AGENTS.md`.

## Verification
- Ran backend test suite successfully (`uv run python -m pytest`).
- Built production bundle successfully with no TypeScript compilation errors (`npm run build`).
