### PR TITLE
chore(agents): add rule to link/close issues in PR descriptions

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -4,6 +4,8 @@
 
 - **GitHub PR Workflow Only**: All changes must be proposed via GitHub Pull Requests. Direct pushes to the `main` branch are strictly forbidden. Always create a feature branch, push the branch, and create a pull request.
 
+- **Link and Close GitHub Issues**: When creating a Pull Request, always include closing keywords (e.g., `Closes #<issue_number>` or `Fixes #<issue_number>`) in the Pull Request description so that the associated issue is automatically closed when the PR is merged.
+
 - **Database Migrations Required**: Any changes to the database schema must include corresponding Alembic migration scripts. The application must run these migrations automatically on startup. Direct/manual changes to production databases are strictly forbidden.
 
 - **Python Management via UV**: This project uses `uv` for Python environment and dependency management. Always run Python/pip related commands, tests, database migrations, and scripts using `uv` (e.g., `uv run`, `uv pip`, etc.).


### PR DESCRIPTION
This PR adds a rule to .agents/AGENTS.md enforcing that all pull requests link/close issues using GitHub closing keywords.