### PR TITLE
docs: update deployment guide to use GHCR pre-built images and clean up README

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,6 +19,9 @@ Portainer organizes multi-container applications using **Stacks** (which use Doc
 
 ### Method A: Web Editor (Pasting Compose File) - Recommended for quick setups
 
+> [!NOTE]
+> Since this method uses pre-built images from the GitHub Container Registry, you do not need to download or clone the source repository on the host server; only the Docker Compose definition is required.
+
 1. Log in to your **Portainer** dashboard.
 2. Select the **Environment** where you want to deploy (e.g., `local`).
 3. Click on **Stacks** in the left sidebar, then click **Add stack** in the top right.
@@ -27,13 +30,9 @@ Portainer organizes multi-container applications using **Stacks** (which use Doc
 6. Paste the following production-ready Compose definition:
 
 ```yaml
-version: '3.8'
-
 services:
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ghcr.io/cfassoni/fitdaysweb/backend:latest
     container_name: fitdays-backend
     environment:
       - DATABASE_URL=sqlite:////app/data/fitdays.db
@@ -46,9 +45,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    image: ghcr.io/cfassoni/fitdaysweb/frontend:latest
     container_name: fitdays-frontend
     ports:
       - "80:80"
@@ -73,9 +70,34 @@ If your code is hosted on an internal Git server (e.g., GitLab, Gitea, GitHub En
 4. Fill in your Git repository details:
    - **Repository URL**: `https://github.com/YOUR_USERNAME/FitdaysWeb.git` (or your internal URL)
    - **Repository reference**: `refs/heads/main`
-   - **Compose path**: `docker-compose.yml`
+   - **Compose path**: `docker-compose.prod.yml` *(Note: We use `docker-compose.prod.yml` here as it points to the pre-built GHCR images, avoiding compilation/build overhead on the host server)*
 5. Enable **Authentication** if your repository is private, and input your credentials / Personal Access Token (PAT).
 6. Enable **Automatic updates** (Webhook or Polling) if you want Portainer to redeploy the stack whenever new code is pushed to your git branch.
+
+---
+
+## 📌 Pinning Image Versions
+
+By default, the production Compose configurations pull the `latest` image tags:
+- `ghcr.io/cfassoni/fitdaysweb/backend:latest`
+- `ghcr.io/cfassoni/fitdaysweb/frontend:latest`
+
+While `latest` is useful for automatic updates, it is highly recommended to pin your deployment to specific tagged releases in production (e.g., `v0.1.0`) to avoid unexpected changes.
+
+To pin a specific version:
+1. Identify the version tag you want to deploy from the repository's releases or GitHub Packages page.
+2. Edit your Compose configuration (either in the Portainer Web Editor for Method A, or by committing changes to your repository if using Method B).
+3. Replace `:latest` with your specific version tag:
+   ```yaml
+   services:
+     backend:
+       image: ghcr.io/cfassoni/fitdaysweb/backend:v0.1.0
+       # ...
+     frontend:
+       image: ghcr.io/cfassoni/fitdaysweb/frontend:v0.1.0
+       # ...
+   ```
+4. Redeploy or update the stack in Portainer.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,42 +45,6 @@ A modern, full-stack application designed to import, parse, store, and visualize
 
 ---
 
-## 📁 Project Structure
-
-```text
-FitdaysWeb/
-├── backend/                  # FastAPI Backend
-│   ├── app/
-│   │   ├── routers/          # Users and records API endpoints
-│   │   ├── auth.py           # JWT generation and security utilities
-│   │   ├── database.py       # SQLAlchemy engine & session setup
-│   │   ├── models.py         # SQLAlchemy tables (User, FitdaysRecord)
-│   │   ├── parser.py         # Fitdays CSV parser logic
-│   │   ├── schemas.py        # Pydantic validation schemas
-│   │   └── main.py           # FastAPI entrypoint and CORS setup
-│   ├── tests/                # Pytest suite
-│   ├── Dockerfile            # Python-slim Docker instructions
-│   └── pyproject.toml        # Backend dependencies definition
-│
-├── frontend/                 # Vite + React Frontend
-│   ├── src/
-│   │   ├── components/       # Reusable components (Sidebar, ThemeToggle)
-│   │   ├── lib/              # API Client helper (api.ts)
-│   │   ├── views/            # Screen views (Dashboard, History, Import, Auth)
-│   │   ├── App.tsx           # Router and auth orchestrator
-│   │   ├── index.css         # Tailwind v4 directives & light/dark mode variables
-│   │   └── main.tsx          # React render entrypoint
-│   ├── nginx.conf            # Nginx reverse proxy configuration
-│   ├── Dockerfile            # Multi-stage Node builder + Nginx image instructions
-│   └── package.json          # Node dependencies definition
-│
-├── test-data/                # Ignored folder housing sample Fitdays exports
-├── docker-compose.yml        # Multi-container coordinator
-└── README.md                 # Project documentation
-```
-
----
-
 ## ⚙️ Getting Started
 
 ### Option A: Running with Docker Desktop (Recommended)
@@ -107,25 +71,20 @@ For deploying this application in a production environment via Portainer.io stac
 If you prefer to run the components separately without Docker:
 
 #### 1. Setup Backend
+
+This project uses `uv` for Python environment and dependency management.
+
 1. Navigate to the `backend/` directory:
    ```bash
    cd backend
    ```
-2. Create and activate a Python virtual environment:
+2. Sync the dependencies and initialize the virtual environment:
    ```bash
-   python -m venv .venv
-   # Windows:
-   .venv\Scripts\activate
-   # Linux/macOS:
-   source .venv/bin/activate
+   uv sync
    ```
-3. Install dependencies:
+3. Launch the dev server:
    ```bash
-   pip install -r pyproject.toml # or use `uv pip sync` / `pip install .`
-   ```
-4. Launch the dev server:
-   ```bash
-   uvicorn app.main:app --reload
+   uv run uvicorn app.main:app --reload
    ```
    *The backend will run on `http://localhost:8000`.*
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,26 @@
+services:
+  backend:
+    image: ghcr.io/cfassoni/fitdaysweb/backend:latest
+    container_name: fitdays-backend
+    environment:
+      - DATABASE_URL=sqlite:////app/data/fitdays.db
+      - UPLOAD_DIR=/app/data/uploads/profile_pics
+      - REPORTS_DIR=/app/data/uploads/reports
+      - SECRET_KEY=${SECRET_KEY}
+      - ACCESS_TOKEN_EXPIRE_MINUTES=${ACCESS_TOKEN_EXPIRE_MINUTES:-1440}
+    volumes:
+      - fitdays-db-data:/app/data
+    restart: unless-stopped
+
+  frontend:
+    image: ghcr.io/cfassoni/fitdaysweb/frontend:latest
+    container_name: fitdays-frontend
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  fitdays-db-data:
+    driver: local


### PR DESCRIPTION
This PR implements the changes requested in #22:
- Replaces source build directives in Portainer Web Editor compose examples in DEPLOYMENT.md with pre-built GHCR images.
- Creates docker-compose.prod.yml to support Method B (Repository) without compilation/build overhead on the host.
- Adds instructions to pin image versions to specific tags instead of pulling latest.
- Removes the redundant Project Structure section from README.md and updates backend setup commands to use uv.

Closes #22