### PR TITLE
feat(frontend): move github and bug icons into version component

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,21 +9,7 @@ import {
   ChevronRight,
   Link2
 } from 'lucide-react';
-import packageJson from '../../package.json';
-
-const GithubIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth="2"
-    fill="none"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    {...props}
-  >
-    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
-  </svg>
-);
+import Version from './Version';
 
 interface SidebarProps {
   currentView: 'dashboard' | 'history' | 'import' | 'profile' | 'shared_links';
@@ -110,18 +96,7 @@ export default function Sidebar({ currentView, onViewChange, isMobileOpen, onMob
 
             {/* Version Info */}
             <div className="border-t border-border pt-4 mt-auto">
-              <div className="flex items-center justify-center gap-2 text-muted-foreground/60 text-xs">
-                <a 
-                  href={`https://github.com/cfassoni/FitdaysWeb/releases/tag/v${packageJson.version}`}
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="hover:text-foreground transition-colors inline-flex items-center gap-1.5"
-                  title="FitdaysWeb Releases"
-                >
-                  <GithubIcon className="h-4 w-4" />
-                  <span className="font-mono">v{packageJson.version}</span>
-                </a>
-              </div>
+              <Version />
             </div>
           </div>
         </div>
@@ -186,20 +161,7 @@ export default function Sidebar({ currentView, onViewChange, isMobileOpen, onMob
 
         {/* Version Info */}
         <div className="p-4 border-t border-border mt-auto">
-          <div className="flex items-center justify-center gap-2 text-muted-foreground/60 text-xs">
-            <a 
-              href={`https://github.com/cfassoni/FitdaysWeb/releases/tag/v${packageJson.version}`}
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="hover:text-foreground transition-colors inline-flex items-center gap-1.5"
-              title="FitdaysWeb Releases"
-            >
-              <GithubIcon className="h-4 w-4" />
-              {!isCollapsed && (
-                <span className="font-mono animate-in fade-in duration-200">v{packageJson.version}</span>
-              )}
-            </a>
-          </div>
+          <Version isCollapsed={isCollapsed} />
         </div>
       </aside>
     </>

--- a/frontend/src/components/TopToolbar.tsx
+++ b/frontend/src/components/TopToolbar.tsx
@@ -1,4 +1,4 @@
-import { Menu, Bug } from 'lucide-react';
+import { Menu } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Logo from './Logo';
 import IconButton from './IconButton';
@@ -6,21 +6,6 @@ import ThemeToggle from './ThemeToggle';
 import LanguageMenu from './LanguageMenu';
 import UserMenu from './UserMenu';
 import type { User } from '../lib/api';
-
-const GithubIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth="2"
-    fill="none"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className="h-5 w-5"
-    {...props}
-  >
-    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
-  </svg>
-);
 
 interface TopToolbarProps {
   user: User | null;
@@ -38,8 +23,6 @@ export default function TopToolbar({
   onMobileMenuToggle,
 }: TopToolbarProps) {
   const { t } = useTranslation();
-  const GITHUB_REPO = 'https://github.com/cfassoni/FitdaysWeb';
-  const GITHUB_ISSUES = 'https://github.com/cfassoni/FitdaysWeb/issues';
 
   return (
     <header className="flex h-16 w-full items-center justify-between border-b border-border bg-card px-4 md:px-6 sticky top-0 z-40">
@@ -57,32 +40,8 @@ export default function TopToolbar({
         <Logo />
       </div>
 
-      {/* Right Area: Controls (ordered from rightmost inward: User, Theme, Language, Bug, GitHub) */}
+      {/* Right Area: Controls (ordered from rightmost inward: User, Theme, Language) */}
       <div className="flex items-center gap-1.5 md:gap-2">
-        {/* GitHub link */}
-        <a
-          href={GITHUB_REPO}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={t('toolbar.supportUs')}
-          aria-label={t('toolbar.openGithub')}
-          className="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
-        >
-          <GithubIcon />
-        </a>
-
-        {/* Bug icon link */}
-        <a
-          href={GITHUB_ISSUES}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={t('toolbar.reportBug')}
-          aria-label={t('toolbar.openIssues')}
-          className="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
-        >
-          <Bug className="h-5 w-5" />
-        </a>
-
         {/* Language selector flyout */}
         <LanguageMenu
           user={user}

--- a/frontend/src/components/Version.tsx
+++ b/frontend/src/components/Version.tsx
@@ -1,0 +1,86 @@
+import { Bug } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import packageJson from '../../package.json';
+
+const GithubIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth="2"
+    fill="none"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+  </svg>
+);
+
+interface VersionProps {
+  isCollapsed?: boolean;
+}
+
+const GITHUB_REPO = 'https://github.com/cfassoni/FitdaysWeb';
+const GITHUB_ISSUES = 'https://github.com/cfassoni/FitdaysWeb/issues';
+const RELEASE_URL = `https://github.com/cfassoni/FitdaysWeb/releases/tag/v${packageJson.version}`;
+
+export default function Version({ isCollapsed = false }: VersionProps) {
+  const { t } = useTranslation();
+
+  if (isCollapsed) {
+    return (
+      <div className="flex items-center justify-center text-muted-foreground/60 text-xs">
+        <a
+          href={GITHUB_REPO}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={t('version.github')}
+          aria-label={t('version.githubAria')}
+          className="hover:text-foreground transition-colors inline-flex items-center justify-center p-1 rounded-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
+        >
+          <GithubIcon className="h-4 w-4" />
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-2.5 text-muted-foreground/60 text-xs">
+      {/* GitHub Repository link */}
+      <a
+        href={GITHUB_REPO}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={t('version.github')}
+        aria-label={t('version.githubAria')}
+        className="hover:text-foreground transition-colors inline-flex items-center justify-center p-0.5 rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
+      >
+        <GithubIcon className="h-4 w-4" />
+      </a>
+
+      {/* Bug Tracker link */}
+      <a
+        href={GITHUB_ISSUES}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={t('version.bug')}
+        aria-label={t('version.bugAria')}
+        className="hover:text-foreground transition-colors inline-flex items-center justify-center p-0.5 rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
+      >
+        <Bug className="h-4 w-4" />
+      </a>
+
+      {/* Release Version link */}
+      <a
+        href={RELEASE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={t('version.release')}
+        aria-label={t('version.releaseAria', { version: packageJson.version })}
+        className="hover:text-foreground transition-colors inline-flex items-center gap-1 font-mono hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
+      >
+        <span>v{packageJson.version}</span>
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/TopToolbar.test.tsx
+++ b/frontend/src/components/__tests__/TopToolbar.test.tsx
@@ -13,10 +13,6 @@ vi.mock('react-i18next', () => ({
         'sidebar.import': 'Import CSV Data',
         'common.logout': 'Logout',
         'toolbar.toggleMenu': 'Toggle navigation menu',
-        'toolbar.supportUs': 'support us!',
-        'toolbar.openGithub': 'Open GitHub project (opens in new tab)',
-        'toolbar.reportBug': 'report bug',
-        'toolbar.openIssues': 'Open issues (opens in new tab)',
         'toolbar.toggleLanguage': 'Change Language: English',
         'toolbar.userMenu': 'User profile menu',
         'toolbar.editProfile': 'Edit Profile',
@@ -83,16 +79,10 @@ describe('TopToolbar', () => {
     // Branding / Logo text should be in document
     expect(screen.getByText('FitdaysWeb')).toBeInTheDocument();
 
-    // External links
-    const githubLink = screen.getByTitle('support us!');
-    expect(githubLink).toBeInTheDocument();
-    expect(githubLink).toHaveAttribute('href', 'https://github.com/cfassoni/FitdaysWeb');
-    expect(githubLink).toHaveAttribute('target', '_blank');
-
-    const bugLink = screen.getByTitle('report bug');
-    expect(bugLink).toBeInTheDocument();
-    expect(bugLink).toHaveAttribute('href', 'https://github.com/cfassoni/FitdaysWeb/issues');
-    expect(bugLink).toHaveAttribute('target', '_blank');
+    // Controls should be present
+    expect(screen.getByLabelText('Toggle navigation menu')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Language selector/)).toBeInTheDocument();
+    expect(screen.getByLabelText('User profile menu')).toBeInTheDocument();
   });
 
   it('triggers mobile menu toggle when hamburger icon is clicked', () => {

--- a/frontend/src/components/__tests__/Version.test.tsx
+++ b/frontend/src/components/__tests__/Version.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import Version from '../Version';
+import packageJson from '../../../package.json';
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      const translations: Record<string, string> = {
+        'version.github': 'Support us on GitHub',
+        'version.githubAria': 'Open GitHub project (opens in new tab)',
+        'version.bug': 'Report an issue',
+        'version.bugAria': 'Open issue tracker (opens in new tab)',
+        'version.release': 'FitdaysWeb releases',
+      };
+      if (key === 'version.releaseAria') {
+        return `Open release notes for v${options?.version} (opens in new tab)`;
+      }
+      return translations[key] || key;
+    },
+    i18n: {
+      language: 'en',
+    },
+  }),
+}));
+
+describe('Version', () => {
+  it('renders all links in expanded mode in correct order with accessible labels and attributes', () => {
+    render(<Version />);
+
+    // Check GitHub link
+    const githubLink = screen.getByLabelText('Open GitHub project (opens in new tab)');
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/cfassoni/FitdaysWeb');
+    expect(githubLink).toHaveAttribute('target', '_blank');
+    expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(githubLink).toHaveAttribute('title', 'Support us on GitHub');
+
+    // Check Bug link
+    const bugLink = screen.getByLabelText('Open issue tracker (opens in new tab)');
+    expect(bugLink).toBeInTheDocument();
+    expect(bugLink).toHaveAttribute('href', 'https://github.com/cfassoni/FitdaysWeb/issues');
+    expect(bugLink).toHaveAttribute('target', '_blank');
+    expect(bugLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(bugLink).toHaveAttribute('title', 'Report an issue');
+
+    // Check Release Version link
+    const releaseLink = screen.getByLabelText(`Open release notes for v${packageJson.version} (opens in new tab)`);
+    expect(releaseLink).toBeInTheDocument();
+    expect(releaseLink).toHaveAttribute('href', `https://github.com/cfassoni/FitdaysWeb/releases/tag/v${packageJson.version}`);
+    expect(releaseLink).toHaveAttribute('target', '_blank');
+    expect(releaseLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(releaseLink).toHaveAttribute('title', 'FitdaysWeb releases');
+    expect(screen.getByText(`v${packageJson.version}`)).toBeInTheDocument();
+  });
+
+  it('renders only GitHub icon link when isCollapsed is true', () => {
+    render(<Version isCollapsed={true} />);
+
+    // GitHub link should be present
+    const githubLink = screen.getByLabelText('Open GitHub project (opens in new tab)');
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/cfassoni/FitdaysWeb');
+
+    // Bug and version links should not be present
+    expect(screen.queryByLabelText('Open issue tracker (opens in new tab)')).not.toBeInTheDocument();
+    expect(screen.queryByText(`v${packageJson.version}`)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -78,10 +78,6 @@
   },
   "toolbar": {
     "toggleMenu": "Toggle navigation menu",
-    "supportUs": "support us!",
-    "openGithub": "Open GitHub project (opens in new tab)",
-    "reportBug": "report bug",
-    "openIssues": "Open issues (opens in new tab)",
     "toggleLanguage": "Change Language: {{lang}}",
     "currentLanguage": "Language selector, current language: {{lang}}",
     "userMenu": "User profile menu",
@@ -89,6 +85,14 @@
     "logout": "Logout",
     "switchToDark": "Switch to Dark Mode",
     "switchToLight": "Switch to Light Mode"
+  },
+  "version": {
+    "github": "Support us on GitHub",
+    "githubAria": "Open GitHub project (opens in new tab)",
+    "bug": "Report an issue",
+    "bugAria": "Open issue tracker (opens in new tab)",
+    "release": "FitdaysWeb releases",
+    "releaseAria": "Open release notes for v{{version}} (opens in new tab)"
   },
   "dashboard": {
     "title": "Progress Dashboard",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -78,10 +78,6 @@
   },
   "toolbar": {
     "toggleMenu": "Alternar menú de navegación",
-    "supportUs": "¡apóyanos!",
-    "openGithub": "Abrir proyecto en GitHub (abre en nueva pestaña)",
-    "reportBug": "reportar error",
-    "openIssues": "Abrir problemas (abre en nueva pestaña)",
     "toggleLanguage": "Cambiar Idioma: {{lang}}",
     "currentLanguage": "Selector de idioma, idioma actual: {{lang}}",
     "userMenu": "Menú de perfil de usuario",
@@ -89,6 +85,14 @@
     "logout": "Cerrar Sesión",
     "switchToDark": "Cambiar a Modo Oscuro",
     "switchToLight": "Cambiar a Modo Claro"
+  },
+  "version": {
+    "github": "Apóyanos en GitHub",
+    "githubAria": "Abrir proyecto en GitHub (abre en nueva pestaña)",
+    "bug": "Reportar un problema",
+    "bugAria": "Abrir rastreador de problemas (abre en nueva pestaña)",
+    "release": "Lanzamientos de FitdaysWeb",
+    "releaseAria": "Abrir notas de la versión v{{version}} (abre en nueva pestaña)"
   },
   "dashboard": {
     "title": "Tablero de Progreso",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -78,10 +78,6 @@
   },
   "toolbar": {
     "toggleMenu": "Alternar menu de navegação",
-    "supportUs": "apoie-nos!",
-    "openGithub": "Abrir projeto no GitHub (abre em nova guia)",
-    "reportBug": "reportar bug",
-    "openIssues": "Abrir problemas (abre em nova guia)",
     "toggleLanguage": "Alterar Idioma: {{lang}}",
     "currentLanguage": "Seletor de idioma, idioma atual: {{lang}}",
     "userMenu": "Menu de perfil do usuário",
@@ -89,6 +85,14 @@
     "logout": "Sair",
     "switchToDark": "Alternar para Modo Escuro",
     "switchToLight": "Alternar para Modo Claro"
+  },
+  "version": {
+    "github": "Apoie-nos no GitHub",
+    "githubAria": "Abrir projeto no GitHub (abre em nova guia)",
+    "bug": "Reportar um problema",
+    "bugAria": "Abrir rastreador de problemas (abre em nova guia)",
+    "release": "Lançamentos do FitdaysWeb",
+    "releaseAria": "Abrir notas da versão v{{version}} (abre em nova guia)"
   },
   "dashboard": {
     "title": "Painel de Progresso",


### PR DESCRIPTION
## Summary

Moves the GitHub and Bug icon links out of the top toolbar and into a dedicated \Version\ component alongside the release version string, keeping the toolbar clean and maintaining center-alignment in the sidebar footer.

- Created `Version.tsx` component displaying `[GitHub] [Bug] [vX.Y.Z]` centered horizontally.
- Handled collapsed sidebar mode gracefully.
- Removed GitHub and Bug links from `TopToolbar.tsx`.
- Added i18n keys for `version.*` in `en.json`, `pt.json`, and `es.json`.
- Added unit tests in `Version.test.tsx` and updated `TopToolbar.test.tsx`.

Closes #30