### PR TITLE
feat(profile): move settings into tabbed layout with security and real-time age

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -35,6 +35,7 @@ from app.schemas import (
     ValidateResetTokenResponse,
     ResetPasswordRequest,
     ResetPasswordResponse,
+    ChangePasswordRequest,
     DeleteDataRequest,
     DeleteAccountRequest,
     DeleteDataResponse,
@@ -349,6 +350,34 @@ def reset_password(data: ResetPasswordRequest, db: Session = Depends(get_db)):
         token_type="bearer",
         message="Password reset successfully"
     )
+
+@router.post("/change-password", response_model=MessageResponse)
+def change_password(
+    data: ChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    if not verify_password(data.current_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect"
+        )
+
+    current_user.hashed_password = get_password_hash(data.new_password)
+    current_user.reset_password_token = None
+    current_user.reset_password_code = None
+    current_user.reset_password_expires_at = None
+    current_user.reset_password_attempts = 0
+    db.commit()
+
+    logger.info(f"[SECURITY] User password changed: user_id={current_user.id}, email={current_user.email}")
+
+    send_password_reset_confirmation_email(
+        to_email=current_user.email,
+        language=current_user.preferred_language
+    )
+
+    return MessageResponse(message="Password changed successfully")
 
 @router.post("/cancel-email-change", response_model=MessageResponse)
 def cancel_email_change(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -115,6 +115,10 @@ class ResetPasswordResponse(BaseModel):
     token_type: str
     message: str
 
+class ChangePasswordRequest(BaseModel):
+    current_password: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=6)
+
 class DeleteDataRequest(BaseModel):
     password: str = Field(..., min_length=1)
 

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -1,0 +1,125 @@
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import User
+from app.auth import get_password_hash, verify_password
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+@pytest.fixture(name="client")
+def client_fixture():
+    app.dependency_overrides[get_db] = override_get_db
+    Base.metadata.create_all(bind=engine)
+    yield TestClient(app)
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.pop(get_db, None)
+
+
+def create_test_user(email="pwduser@example.com", password="oldpassword123"):
+    db = TestingSessionLocal()
+    user = User(
+        email=email,
+        hashed_password=get_password_hash(password),
+        display_name="Password Tester",
+        gender="male",
+        birthday="1992-04-20",
+        height_cm=175.0,
+        target_weight_kg=70.0,
+        preferred_language="pt",
+        email_confirmed=True
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+    db.close()
+    return user_id
+
+
+@patch("app.routers.users.send_password_reset_confirmation_email")
+def test_change_password_success(mock_email, client: TestClient):
+    create_test_user()
+
+    login_resp = client.post("/api/users/login", data={"username": "pwduser@example.com", "password": "oldpassword123"})
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Change password
+    resp = client.post(
+        "/api/users/change-password",
+        json={"current_password": "oldpassword123", "new_password": "newsecurepassword456"},
+        headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Password changed successfully"
+
+    # Verify confirmation email sent
+    mock_email.assert_called_once_with(to_email="pwduser@example.com", language="pt")
+
+    # Verify old password fails login
+    old_login = client.post("/api/users/login", data={"username": "pwduser@example.com", "password": "oldpassword123"})
+    assert old_login.status_code == 401
+
+    # Verify new password succeeds login
+    new_login = client.post("/api/users/login", data={"username": "pwduser@example.com", "password": "newsecurepassword456"})
+    assert new_login.status_code == 200
+
+
+def test_change_password_wrong_current_password(client: TestClient):
+    create_test_user()
+
+    login_resp = client.post("/api/users/login", data={"username": "pwduser@example.com", "password": "oldpassword123"})
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = client.post(
+        "/api/users/change-password",
+        json={"current_password": "incorrectpassword", "new_password": "newsecurepassword456"},
+        headers=headers
+    )
+    assert resp.status_code == 400
+    assert "Current password is incorrect" in resp.json()["detail"]
+
+
+def test_change_password_short_password(client: TestClient):
+    create_test_user()
+
+    login_resp = client.post("/api/users/login", data={"username": "pwduser@example.com", "password": "oldpassword123"})
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = client.post(
+        "/api/users/change-password",
+        json={"current_password": "oldpassword123", "new_password": "123"},
+        headers=headers
+    )
+    assert resp.status_code == 422  # Pydantic validation error for min_length=6
+
+
+def test_change_password_unauthenticated(client: TestClient):
+    resp = client.post(
+        "/api/users/change-password",
+        json={"current_password": "oldpassword123", "new_password": "newsecurepassword456"}
+    )
+    assert resp.status_code == 401

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -375,6 +375,16 @@ export const api = {
     });
   },
 
+  async changePassword(currentPassword: string, newPassword: string): Promise<{ message: string }> {
+    return apiFetch<{ message: string }>('/api/users/change-password', {
+      method: 'POST',
+      json: {
+        current_password: currentPassword,
+        new_password: newPassword,
+      },
+    });
+  },
+
   async getSummary(): Promise<DashboardSummary> {
     return apiFetch<DashboardSummary>('/api/records/summary', {
       method: 'GET',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -322,19 +322,42 @@
       "photoErrorSize": "Profile picture must be less than 4MB",
       "photoErrorType": "Only JPEG, PNG, and WebP images are allowed"
     },
+    "tabs": {
+      "account": "Account Information",
+      "personal": "Personal Details",
+      "security": "Security",
+      "privacy": "Privacy"
+    },
     "sections": {
       "credentials": "Account Information",
-      "personal": "Personal details",
+      "personal": "Personal Details",
       "physical": "Physical specifications"
     },
     "fields": {
       "email": "Email Address",
       "displayName": "Display Name",
       "birthday": "Birthday",
+      "age": "Age",
+      "ageUnit": "{{count}} years",
+      "ageUnset": "—",
       "gender": "Gender",
       "language": "Preferred Language",
       "height": "Height (cm)",
       "weight": "Target Weight (kg)"
+    },
+    "security": {
+      "title": "Password & Security",
+      "subtitle": "Manage your account password to keep your data secure",
+      "currentPassword": "Current Password",
+      "currentPasswordPlaceholder": "Enter current password",
+      "newPassword": "New Password",
+      "newPasswordPlaceholder": "Enter new password (min. 6 characters)",
+      "confirmPassword": "Confirm New Password",
+      "confirmPasswordPlaceholder": "Re-enter new password",
+      "changePasswordBtn": "Update Password",
+      "passwordChangedSuccess": "Your password has been changed successfully!",
+      "passwordsDoNotMatch": "New password and confirmation do not match",
+      "passwordTooShort": "Password must be at least 6 characters long"
     },
     "editEmail": "Edit email",
     "pendingEmailNotice": "Email change pending verification for {{email}}",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -322,19 +322,42 @@
       "photoErrorSize": "La foto de perfil debe pesar menos de 4MB",
       "photoErrorType": "Solo se permiten imágenes JPEG, PNG y WebP"
     },
+    "tabs": {
+      "account": "Información de la Cuenta",
+      "personal": "Datos Personales",
+      "security": "Seguridad",
+      "privacy": "Privacidad"
+    },
     "sections": {
       "credentials": "Información de la Cuenta",
-      "personal": "Datos personales",
+      "personal": "Datos Personales",
       "physical": "Especificaciones físicas"
     },
     "fields": {
       "email": "Dirección de Correo Electrónico",
       "displayName": "Nombre de Mostrar",
       "birthday": "Fecha de Nacimiento",
+      "age": "Edad",
+      "ageUnit": "{{count}} años",
+      "ageUnset": "—",
       "gender": "Género",
       "language": "Idioma Preferido",
       "height": "Altura (cm)",
       "weight": "Peso Objetivo (kg)"
+    },
+    "security": {
+      "title": "Contraseña y Seguridad",
+      "subtitle": "Administra la contraseña de tu cuenta para mantener tus datos seguros",
+      "currentPassword": "Contraseña Actual",
+      "currentPasswordPlaceholder": "Ingresa tu contraseña actual",
+      "newPassword": "Nueva Contraseña",
+      "newPasswordPlaceholder": "Ingresa tu nueva contraseña (mín. 6 caracteres)",
+      "confirmPassword": "Confirmar Nueva Contraseña",
+      "confirmPasswordPlaceholder": "Vuelve a ingresar la nueva contraseña",
+      "changePasswordBtn": "Actualizar Contraseña",
+      "passwordChangedSuccess": "¡Tu contraseña ha sido cambiada con éxito!",
+      "passwordsDoNotMatch": "La nueva contraseña y la confirmación no coinciden",
+      "passwordTooShort": "La contraseña debe tener al menos 6 caracteres"
     },
     "editEmail": "Editar correo",
     "pendingEmailNotice": "Cambio de correo pendiente de verificación para {{email}}",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -322,19 +322,42 @@
       "photoErrorSize": "A foto de perfil deve ter menos de 4MB",
       "photoErrorType": "Apenas imagens JPEG, PNG e WebP são permitidas"
     },
+    "tabs": {
+      "account": "Informações da Conta",
+      "personal": "Dados Pessoais",
+      "security": "Segurança",
+      "privacy": "Privacidade"
+    },
     "sections": {
       "credentials": "Informações da Conta",
-      "personal": "Dados pessoais",
+      "personal": "Dados Pessoais",
       "physical": "Especificações físicas"
     },
     "fields": {
       "email": "Endereço de E-mail",
       "displayName": "Nome de Exibição",
       "birthday": "Data de Nascimento",
+      "age": "Idade",
+      "ageUnit": "{{count}} anos",
+      "ageUnset": "—",
       "gender": "Gênero",
       "language": "Idioma Preferido",
       "height": "Altura (cm)",
       "weight": "Peso Ideal (kg)"
+    },
+    "security": {
+      "title": "Senha e Segurança",
+      "subtitle": "Gerencie a senha da sua conta para manter seus dados seguros",
+      "currentPassword": "Senha Atual",
+      "currentPasswordPlaceholder": "Digite a senha atual",
+      "newPassword": "Nova Senha",
+      "newPasswordPlaceholder": "Digite a nova senha (mín. 6 caracteres)",
+      "confirmPassword": "Confirmar Nova Senha",
+      "confirmPasswordPlaceholder": "Digite novamente a nova senha",
+      "changePasswordBtn": "Atualizar Senha",
+      "passwordChangedSuccess": "Sua senha foi alterada com sucesso!",
+      "passwordsDoNotMatch": "A nova senha e a confirmação não coincidem",
+      "passwordTooShort": "A senha deve ter pelo menos 6 caracteres"
     },
     "editEmail": "Editar e-mail",
     "pendingEmailNotice": "Alteração de e-mail pendente de verificação para {{email}}",

--- a/frontend/src/views/Profile.tsx
+++ b/frontend/src/views/Profile.tsx
@@ -22,7 +22,11 @@ import {
   Eye,
   EyeOff,
   AlertTriangle,
-  Shield
+  Shield,
+  User as UserIcon,
+  Activity,
+  KeyRound,
+  Lock
 } from 'lucide-react';
 import OtpInput from '../components/OtpInput';
 
@@ -31,13 +35,23 @@ interface ProfileProps {
   onProfileUpdated: (updatedUser: User) => void;
 }
 
+type ProfileTab = 'account' | 'personal' | 'security' | 'privacy';
+
 export default function Profile({ user, onProfileUpdated }: ProfileProps) {
   const { t, i18n } = useTranslation();
+  const [activeTab, setActiveTab] = useState<ProfileTab>('account');
+
+  // Account Information Fields
   const [email, setEmail] = useState(user?.email || '');
   const [isEditingEmail, setIsEditingEmail] = useState(false);
   const [displayName, setDisplayName] = useState(user?.display_name || '');
+  const [preferredLanguage, setPreferredLanguage] = useState(user?.preferred_language || 'en');
+  const [isSavingAccount, setIsSavingAccount] = useState(false);
+  const [accountError, setAccountError] = useState<string | null>(null);
+  const [accountSuccess, setAccountSuccess] = useState(false);
+
+  // Personal Details Fields
   const [gender, setGender] = useState<'male' | 'female'>(user?.gender as 'male' | 'female' || 'male');
-  
   const [birthDay, setBirthDay] = useState(() => {
     const parts = (user?.birthday || '').split('-');
     return parts[2] || '';
@@ -50,10 +64,22 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
     const parts = (user?.birthday || '').split('-');
     return parts[0] || '';
   });
-
   const [heightCm, setHeightCm] = useState(user?.height_cm ? String(user.height_cm) : '');
   const [targetWeightKg, setTargetWeightKg] = useState(user?.target_weight_kg ? String(user.target_weight_kg) : '');
-  const [preferredLanguage, setPreferredLanguage] = useState(user?.preferred_language || 'en');
+  const [isSavingPersonal, setIsSavingPersonal] = useState(false);
+  const [personalError, setPersonalError] = useState<string | null>(null);
+  const [personalSuccess, setPersonalSuccess] = useState(false);
+
+  // Security (Change Password) Fields
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [confirmNewPassword, setConfirmNewPassword] = useState('');
+  const [showConfirmNewPassword, setShowConfirmNewPassword] = useState(false);
+  const [isSavingSecurity, setIsSavingSecurity] = useState(false);
+  const [securityError, setSecurityError] = useState<string | null>(null);
+  const [securitySuccess, setSecuritySuccess] = useState(false);
 
   // OTP Modal State for pending email verification
   const [showVerifyModal, setShowVerifyModal] = useState(false);
@@ -64,6 +90,25 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
   const [resendCooldown, setResendCooldown] = useState(0);
   const [isResending, setIsResending] = useState(false);
   const [resendMessage, setResendMessage] = useState<string | null>(null);
+
+  // Photo upload state
+  const [isPhotoLoading, setIsPhotoLoading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Data Deletion Modal state (Option A)
+  const [showDeleteDataModal, setShowDeleteDataModal] = useState(false);
+  const [deleteDataPassword, setDeleteDataPassword] = useState('');
+  const [showDeleteDataPassword, setShowDeleteDataPassword] = useState(false);
+  const [isDeletingData, setIsDeletingData] = useState(false);
+  const [deleteDataError, setDeleteDataError] = useState<string | null>(null);
+  const [deleteDataSuccess, setDeleteDataSuccess] = useState<string | null>(null);
+
+  // Account Deletion Modal state (Option B)
+  const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
+  const [deleteAccountPassword, setDeleteAccountPassword] = useState('');
+  const [showDeleteAccountPassword, setShowDeleteAccountPassword] = useState(false);
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
 
   useEffect(() => {
     if (resendCooldown <= 0) return;
@@ -113,129 +158,173 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
     }
   }, [birthMonth, birthYear, birthDay]);
 
+  // Real-time Age calculation
+  const calculateAge = (day: string, month: string, year: string): number | null => {
+    if (!day || !month || !year) return null;
+    const d = parseInt(day, 10);
+    const m = parseInt(month, 10) - 1;
+    const y = parseInt(year, 10);
+    if (isNaN(d) || isNaN(m) || isNaN(y)) return null;
+    const birthDate = new Date(y, m, d);
+    if (isNaN(birthDate.getTime())) return null;
+    const today = new Date();
+    let calculated = today.getFullYear() - birthDate.getFullYear();
+    const mDiff = today.getMonth() - birthDate.getMonth();
+    if (mDiff < 0 || (mDiff === 0 && today.getDate() < birthDate.getDate())) {
+      calculated--;
+    }
+    return calculated >= 0 ? calculated : null;
+  };
+
+  const calculatedAge = calculateAge(birthDay, birthMonth, birthYear);
+  const ageDisplay = calculatedAge !== null 
+    ? t('profile.fields.ageUnit', { count: calculatedAge }) 
+    : t('profile.fields.ageUnset');
+
   const birthday = (birthYear && birthMonth && birthDay) ? `${birthYear}-${birthMonth}-${birthDay}` : '';
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [isPhotoLoading, setIsPhotoLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
+  // Avatar Upload Handler
   const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     if (file.size > 4 * 1024 * 1024) {
-      setError(t('profile.avatarPanel.photoErrorSize'));
+      alert(t('profile.avatarPanel.photoErrorSize'));
       return;
     }
 
     if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
-      setError(t('profile.avatarPanel.photoErrorType'));
+      alert(t('profile.avatarPanel.photoErrorType'));
       return;
     }
 
-    setError(null);
     setIsPhotoLoading(true);
-
     try {
       const updatedUser = await api.uploadProfilePicture(file);
       onProfileUpdated(updatedUser);
-      setSuccess(true);
-      setTimeout(() => setSuccess(false), 3000);
-    } catch (err: any) {
-      setError(err.message || t('profile.uploadPhotoError'));
+    } catch {
+      alert(t('profile.uploadPhotoError'));
     } finally {
       setIsPhotoLoading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
     }
   };
 
-  const handleSave = async (e: React.FormEvent) => {
+  // 1. Account Info Save
+  const handleSaveAccount = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
-    setSuccess(false);
-
-    // Validation
-    if (!email || !displayName || !gender || !birthday || !heightCm || !targetWeightKg || !preferredLanguage) {
-      setError(t('common.required'));
-      return;
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      setError(t('common.validation.invalidEmail'));
-      return;
-    }
-
-    const birthDate = new Date(birthday);
-    const today = new Date();
-    if (isNaN(birthDate.getTime()) || birthDate > today) {
-      setError(t('common.validation.birthdayPast'));
-      return;
-    }
-
-    const h = parseFloat(heightCm);
-    const w = parseFloat(targetWeightKg);
-    if (isNaN(h) || h < 40 || h > 300) {
-      setError(t('common.validation.heightRange'));
-      return;
-    }
-
-    if (isNaN(w) || w < 10 || w > 500) {
-      setError(t('common.validation.weightRange'));
-      return;
-    }
-
-    const langRegex = /^[a-zA-Z]{2}(-[a-zA-Z]{2,4})?$/;
-    if (!langRegex.test(preferredLanguage)) {
-      setError(t('common.validation.langFormat'));
-      return;
-    }
-
-    setIsLoading(true);
+    setIsSavingAccount(true);
+    setAccountError(null);
+    setAccountSuccess(false);
 
     try {
-      const updatedUser = await api.updateProfile({
-        email,
+      const payload: Partial<Omit<User, 'id' | 'created_at' | 'profile_image_path' | 'profile_image_url'>> = {
         display_name: displayName,
-        gender,
-        birthday,
-        height_cm: h,
-        target_weight_kg: w,
-        preferred_language: preferredLanguage
-      });
-      
+        preferred_language: preferredLanguage,
+      };
+
+      if (isEditingEmail && email !== user?.email) {
+        payload.email = email;
+      }
+
+      const updatedUser = await api.updateProfile(payload);
       onProfileUpdated(updatedUser);
+      setAccountSuccess(true);
+      setTimeout(() => setAccountSuccess(false), 3000);
+
+      if (isEditingEmail && email !== user?.email) {
+        setShowVerifyModal(true);
+      }
       setIsEditingEmail(false);
-      setSuccess(true);
-      setTimeout(() => setSuccess(false), 3000);
-    } catch (err: any) {
-      setError(err.message || t('profile.updateError'));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('profile.updateError');
+      setAccountError(msg);
     } finally {
-      setIsLoading(false);
+      setIsSavingAccount(false);
     }
   };
 
-  const handleResendPendingCode = async () => {
+  // 2. Personal Details Save
+  const handleSavePersonal = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSavingPersonal(true);
+    setPersonalError(null);
+    setPersonalSuccess(false);
+
+    try {
+      const payload: Partial<Omit<User, 'id' | 'created_at' | 'profile_image_path' | 'profile_image_url'>> = {
+        gender,
+        birthday: birthday || null,
+        height_cm: heightCm ? parseFloat(heightCm) : null,
+        target_weight_kg: targetWeightKg ? parseFloat(targetWeightKg) : null,
+      };
+
+      const updatedUser = await api.updateProfile(payload);
+      onProfileUpdated(updatedUser);
+      setPersonalSuccess(true);
+      setTimeout(() => setPersonalSuccess(false), 3000);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('profile.updateError');
+      setPersonalError(msg);
+    } finally {
+      setIsSavingPersonal(false);
+    }
+  };
+
+  // 3. Security (Change Password) Submit
+  const handleSaveSecurity = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSecurityError(null);
+    setSecuritySuccess(false);
+
+    if (newPassword !== confirmNewPassword) {
+      setSecurityError(t('profile.security.passwordsDoNotMatch'));
+      return;
+    }
+
+    if (newPassword.length < 6) {
+      setSecurityError(t('profile.security.passwordTooShort'));
+      return;
+    }
+
+    setIsSavingSecurity(true);
+
+    try {
+      await api.changePassword(currentPassword, newPassword);
+      setSecuritySuccess(true);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmNewPassword('');
+      setTimeout(() => setSecuritySuccess(false), 4000);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('common.error');
+      setSecurityError(msg);
+    } finally {
+      setIsSavingSecurity(false);
+    }
+  };
+
+  // Pending Email Resend & Cancel Handlers
+  const handleResendPendingEmailCode = async () => {
     if (!user?.pending_email || resendCooldown > 0 || isResending) return;
     setIsResending(true);
-    setError(null);
     setResendMessage(null);
-
     try {
       await api.resendVerification(user.pending_email);
-      setResendMessage(t('profile.codeSent', { email: user.pending_email }));
       setResendCooldown(60);
-    } catch (err: any) {
-      setError(err.message || t('common.error'));
+      setResendMessage(t('profile.codeSent', { email: user.pending_email }));
+      setTimeout(() => setResendMessage(null), 5000);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('common.error');
+      setAccountError(msg);
     } finally {
       setIsResending(false);
     }
   };
 
-  const handleCancelPendingEmail = async () => {
-    setError(null);
+  const handleCancelPendingEmailChange = async () => {
     try {
       await api.cancelEmailChange();
       const me = await api.getMe();
@@ -243,8 +332,9 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
       setEmail(me.email);
       setIsEditingEmail(false);
       setShowVerifyModal(false);
-    } catch (err: any) {
-      setError(err.message || t('common.error'));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('common.error');
+      setAccountError(msg);
     }
   };
 
@@ -262,30 +352,17 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
       setEmail(me.email);
       setShowVerifyModal(false);
       setVerifyModalCode('');
-      setSuccess(true);
-      setTimeout(() => setSuccess(false), 3000);
-    } catch (err: any) {
-      setVerifyModalError(err.message || t('verifyEmail.errorTitle'));
+      setAccountSuccess(true);
+      setTimeout(() => setAccountSuccess(false), 3000);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('verifyEmail.errorTitle');
+      setVerifyModalError(msg);
     } finally {
       setIsVerifyingCode(false);
     }
   };
 
-  // Data Deletion Modal state
-  const [showDeleteDataModal, setShowDeleteDataModal] = useState(false);
-  const [deleteDataPassword, setDeleteDataPassword] = useState('');
-  const [showDeleteDataPassword, setShowDeleteDataPassword] = useState(false);
-  const [isDeletingData, setIsDeletingData] = useState(false);
-  const [deleteDataError, setDeleteDataError] = useState<string | null>(null);
-  const [deleteDataSuccess, setDeleteDataSuccess] = useState<string | null>(null);
-
-  // Account Deletion Modal state
-  const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
-  const [deleteAccountPassword, setDeleteAccountPassword] = useState('');
-  const [showDeleteAccountPassword, setShowDeleteAccountPassword] = useState(false);
-  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
-  const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
-
+  // Option A Data Deletion Handler
   const handleDeleteUserData = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!deleteDataPassword) return;
@@ -309,6 +386,7 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
     }
   };
 
+  // Option B Account Deletion Handler
   const handleDeleteAccount = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!deleteAccountPassword) return;
@@ -331,11 +409,36 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
     }
   };
 
+  const tabs: Array<{ id: ProfileTab; label: string; icon: typeof UserIcon }> = [
+    { id: 'account', label: t('profile.tabs.account'), icon: UserIcon },
+    { id: 'personal', label: t('profile.tabs.personal'), icon: Activity },
+    { id: 'security', label: t('profile.tabs.security'), icon: KeyRound },
+    { id: 'privacy', label: t('profile.tabs.privacy'), icon: Shield },
+  ];
+
+  const handleTabKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const nextIndex = (index + 1) % tabs.length;
+      setActiveTab(tabs[nextIndex].id);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const prevIndex = (index - 1 + tabs.length) % tabs.length;
+      setActiveTab(tabs[prevIndex].id);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveTab(tabs[0].id);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setActiveTab(tabs[tabs.length - 1].id);
+    }
+  };
+
   return (
     <div className="flex-1 overflow-y-auto p-4 md:p-8 bg-background">
-      <div className="max-w-4xl mx-auto space-y-6">
+      <div className="max-w-5xl mx-auto space-y-6">
         
-        {/* Title */}
+        {/* Page Title */}
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">{t('profile.title')}</h1>
           <p className="text-sm text-muted-foreground mt-0.5">{t('profile.subtitle')}</p>
@@ -343,122 +446,221 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
 
         {/* Pending Email Alert Banner */}
         {user?.pending_email && (
-          <div className="p-4 bg-amber-500/10 border border-amber-500/25 rounded-xl space-y-3">
-            <div className="flex items-start gap-2.5 text-amber-700 dark:text-amber-400 text-sm font-medium">
-              <ShieldAlert className="h-5 w-5 shrink-0 mt-0.5" />
-              <span>{t('profile.pendingEmailNotice', { email: user.pending_email })}</span>
+          <div className="p-4 bg-amber-500/10 border border-amber-500/20 rounded-xl space-y-3">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-start gap-3">
+                <ShieldAlert className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+                <div>
+                  <h4 className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                    {t('profile.pendingEmailNotice', { email: user.pending_email })}
+                  </h4>
+                  <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
+                    {t('profile.verifyModalSubtitle', { email: user.pending_email })}
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={handleCancelPendingEmailChange}
+                className="text-muted-foreground hover:text-foreground text-xs underline cursor-pointer shrink-0"
+              >
+                {t('profile.cancelEmailChange')}
+              </button>
             </div>
-            <div className="flex flex-wrap items-center gap-2 pt-1">
+
+            {resendMessage && (
+              <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium">
+                {resendMessage}
+              </p>
+            )}
+
+            <div className="flex flex-wrap items-center gap-3 pt-1">
               <button
                 type="button"
                 onClick={() => {
+                  setVerifyModalCode('');
                   setVerifyModalError(null);
                   setShowVerifyModal(true);
                 }}
-                className="px-3 py-1.5 bg-primary text-primary-foreground text-xs font-semibold rounded-lg hover:bg-primary/90 transition-colors cursor-pointer"
+                className="px-3 py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold cursor-pointer shadow-xs"
               >
                 {t('profile.enterVerificationCode')}
               </button>
               <button
                 type="button"
-                onClick={handleResendPendingCode}
-                disabled={isResending || resendCooldown > 0}
-                className="px-3 py-1.5 bg-background border border-border text-foreground text-xs font-medium rounded-lg hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 flex items-center gap-1"
+                onClick={handleResendPendingEmailCode}
+                disabled={resendCooldown > 0 || isResending}
+                className="px-3 py-1.5 rounded-lg border border-amber-500/30 hover:bg-amber-500/10 text-amber-800 dark:text-amber-200 text-xs font-medium cursor-pointer disabled:opacity-50 flex items-center gap-1.5"
               >
-                {isResending ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                {isResending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-3.5 w-3.5" />
+                )}
                 <span>
                   {resendCooldown > 0
                     ? `${t('profile.resendVerificationCode')} (${resendCooldown}s)`
                     : t('profile.resendVerificationCode')}
                 </span>
               </button>
-              <button
-                type="button"
-                onClick={handleCancelPendingEmail}
-                className="px-3 py-1.5 bg-destructive/10 border border-destructive/25 text-destructive text-xs font-medium rounded-lg hover:bg-destructive/20 transition-colors cursor-pointer"
-              >
-                {t('profile.cancelEmailChange')}
-              </button>
             </div>
           </div>
         )}
 
-        {resendMessage && (
-          <div className="flex items-center gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-sm animate-in fade-in duration-200">
-            <CheckCircle2 className="h-5 w-5 shrink-0" />
-            <span>{resendMessage}</span>
-          </div>
-        )}
-
-        {error && (
-          <div className="flex items-start gap-2 p-3 bg-destructive/10 border border-destructive/25 text-destructive rounded-lg text-sm animate-in fade-in duration-200">
-            <AlertCircle className="h-5 w-5 shrink-0 mt-0.5" />
-            <span>{error}</span>
-          </div>
-        )}
-
-        {success && (
-          <div className="flex items-center gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-sm animate-in fade-in duration-200">
-            <CheckCircle2 className="h-5 w-5 shrink-0" />
-            <span>{t('profile.successMsg')}</span>
-          </div>
-        )}
-
-        {/* Profile Details Layout */}
+        {/* 2-Column Responsive Layout */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           
-          {/* Avatar Edit Panel */}
-          <div className="lg:col-span-1 bg-card border border-border rounded-xl p-6 flex flex-col items-center justify-center text-center relative overflow-hidden shadow-xs">
-            <div className="relative group cursor-pointer mb-4" onClick={() => fileInputRef.current?.click()}>
-              <div className="h-32 w-32 rounded-full overflow-hidden border-2 border-primary/20 bg-muted flex items-center justify-center relative">
-                {isPhotoLoading ? (
-                  <Loader2 className="h-8 w-8 text-primary animate-spin" />
-                ) : user?.profile_image_url ? (
-                  <img src={user.profile_image_url} alt="Profile" className="h-full w-full object-cover" />
+          {/* Left Column: Persistent Avatar & Profile Overview Card */}
+          <div className="lg:col-span-1 space-y-6">
+            <div className="bg-card border border-border rounded-xl p-6 flex flex-col items-center justify-center text-center relative overflow-hidden shadow-xs">
+              <div 
+                className="relative group cursor-pointer mb-4"
+                onClick={() => fileInputRef.current?.click()}
+                title={t('profile.avatarPanel.changePhoto')}
+              >
+                {user?.profile_image_path ? (
+                  <img
+                    src={`/uploads/profile_pics/${user.profile_image_path.split(/[\\/]/).pop()}`}
+                    alt={user.display_name || user.email}
+                    className="h-32 w-32 rounded-full object-cover border-2 border-primary/20 bg-muted"
+                  />
                 ) : (
-                  <span className="text-4xl font-bold text-primary">
-                    {user?.display_name ? user.display_name.slice(0, 2).toUpperCase() : user?.email.slice(0, 2).toUpperCase()}
-                  </span>
+                  <div className="h-32 w-32 rounded-full overflow-hidden border-2 border-primary/20 bg-muted flex items-center justify-center relative">
+                    <span className="text-4xl font-bold text-primary">
+                      {user?.display_name ? user.display_name.substring(0, 2).toUpperCase() : user?.email.substring(0, 2).toUpperCase()}
+                    </span>
+                  </div>
                 )}
+                <div className="absolute inset-0 bg-black/40 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                  <Camera className="h-8 w-8 text-white" />
+                </div>
               </div>
-              <div className="absolute inset-0 bg-black/40 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                <Camera className="h-8 w-8 text-white" />
-              </div>
-            </div>
-            
-            <h2 className="text-lg font-bold text-foreground">{user?.display_name || user?.email}</h2>
-            <p className="text-xs text-muted-foreground mt-1 mb-4">{user?.email}</p>
-            
-            <input
-              type="file"
-              ref={fileInputRef}
-              accept="image/jpeg,image/png,image/webp"
-              onChange={handlePhotoUpload}
-              className="hidden"
-            />
 
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isPhotoLoading}
-              className="px-4 py-2 rounded-lg border border-input bg-background hover:bg-muted text-sm font-medium text-foreground transition-colors cursor-pointer flex items-center gap-1.5 disabled:opacity-50"
-            >
-              {isPhotoLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-              <span>{t('profile.avatarPanel.changePhoto')}</span>
-            </button>
+              <h2 className="text-lg font-bold text-foreground">
+                {user?.display_name || user?.email.split('@')[0]}
+              </h2>
+              <p className="text-xs text-muted-foreground mt-1 mb-1">{user?.email}</p>
+              {user?.created_at && (
+                <p className="text-[11px] text-muted-foreground/70 mb-4">
+                  {formatDate(user.created_at)}
+                </p>
+              )}
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={handlePhotoUpload}
+              />
+
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isPhotoLoading}
+                className="px-4 py-2 rounded-lg border border-input bg-background hover:bg-muted text-sm font-medium text-foreground transition-colors cursor-pointer flex items-center gap-1.5 disabled:opacity-50"
+              >
+                {isPhotoLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                <span>{t('profile.avatarPanel.changePhoto')}</span>
+              </button>
+            </div>
+
+            {/* Navigation Tabs for Desktop Vertical Sidebar */}
+            <div className="hidden lg:block bg-card border border-border rounded-xl p-2 shadow-xs" role="tablist" aria-orientation="vertical">
+              {tabs.map((tab, idx) => {
+                const Icon = tab.icon;
+                const isActive = activeTab === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    id={`tab-${tab.id}`}
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={`panel-${tab.id}`}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => setActiveTab(tab.id)}
+                    onKeyDown={e => handleTabKeyDown(e, idx)}
+                    className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-colors cursor-pointer text-left ${
+                      isActive 
+                        ? 'bg-primary text-primary-foreground font-semibold shadow-xs' 
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                    }`}
+                  >
+                    <Icon className={`h-4 w-4 shrink-0 ${isActive ? 'text-primary-foreground' : 'text-muted-foreground'}`} />
+                    <span>{tab.label}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
-          {/* Form Panel */}
-          <div className="lg:col-span-2 bg-card border border-border rounded-xl p-6 shadow-xs">
-            <form onSubmit={handleSave} className="space-y-6">
-              
-              {/* Account details */}
-              <div>
-                <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-4 border-b border-border pb-1.5">
-                  {t('profile.sections.credentials')}
-                </h3>
-                <div className="grid grid-cols-1 gap-4">
+          {/* Right Column: Tab Panels */}
+          <div className="lg:col-span-2 space-y-4">
+            
+            {/* Horizontal Tabs Bar for Mobile/Tablet Screens */}
+            <div className="lg:hidden flex overflow-x-auto p-1 bg-muted/60 border border-border rounded-xl gap-1" role="tablist" aria-orientation="horizontal">
+              {tabs.map((tab, idx) => {
+                const Icon = tab.icon;
+                const isActive = activeTab === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    id={`tab-mobile-${tab.id}`}
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={`panel-${tab.id}`}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => setActiveTab(tab.id)}
+                    onKeyDown={e => handleTabKeyDown(e, idx)}
+                    className={`flex-1 min-w-[120px] flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all cursor-pointer whitespace-nowrap ${
+                      isActive 
+                        ? 'bg-card text-foreground font-semibold shadow-xs' 
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    <Icon className="h-3.5 w-3.5 shrink-0" />
+                    <span>{tab.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* TAB 1: Account Information */}
+            {activeTab === 'account' && (
+              <div 
+                id="panel-account" 
+                role="tabpanel" 
+                aria-labelledby="tab-account"
+                className="bg-card border border-border rounded-xl p-6 shadow-xs animate-in fade-in-50 duration-200"
+              >
+                <div className="flex items-center gap-3 mb-6 pb-4 border-b border-border">
+                  <div className="p-2 rounded-lg bg-primary/10 text-primary">
+                    <UserIcon className="h-5 w-5" />
+                  </div>
                   <div>
-                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="email">
+                    <h3 className="text-base font-semibold text-foreground">{t('profile.tabs.account')}</h3>
+                    <p className="text-xs text-muted-foreground">{t('profile.subtitle')}</p>
+                  </div>
+                </div>
+
+                {accountSuccess && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-xs animate-in fade-in duration-200">
+                    <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{t('profile.successMsg')}</span>
+                  </div>
+                )}
+
+                {accountError && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-destructive/10 border border-destructive/25 text-destructive rounded-lg text-xs">
+                    <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{accountError}</span>
+                  </div>
+                )}
+
+                <form onSubmit={handleSaveAccount} className="space-y-6">
+                  {/* Email Address */}
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="account-email">
                       {t('profile.fields.email')}
                     </label>
                     <div className="relative flex items-center">
@@ -466,16 +668,15 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
                         <Mail className="h-4 w-4" />
                       </span>
                       <input
-                        id="email"
+                        id="account-email"
                         type="email"
                         value={email}
-                        readOnly={!isEditingEmail}
                         onChange={e => setEmail(e.target.value)}
-                        disabled={isLoading}
-                        className={`w-full pl-9 pr-10 py-2 rounded-lg border text-sm transition-all ${
-                          isEditingEmail
-                            ? 'border-primary bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent'
-                            : 'border-input bg-muted/50 text-foreground cursor-default'
+                        disabled={!isEditingEmail}
+                        className={`w-full pl-9 pr-10 py-2.5 rounded-lg border text-sm transition-colors ${
+                          !isEditingEmail 
+                            ? 'bg-muted/40 text-muted-foreground border-input cursor-not-allowed select-none' 
+                            : 'bg-background text-foreground border-input focus:outline-hidden focus:ring-2 focus:ring-primary'
                         }`}
                       />
                       <button
@@ -488,289 +689,495 @@ export default function Profile({ user, onProfileUpdated }: ProfileProps) {
                             setIsEditingEmail(true);
                           }
                         }}
+                        className="absolute inset-y-0 right-0 pr-3 flex items-center text-muted-foreground hover:text-foreground cursor-pointer"
                         title={isEditingEmail ? t('common.cancel') : t('profile.editEmail')}
-                        className="absolute inset-y-0 right-0 pr-3 flex items-center text-muted-foreground hover:text-primary transition-colors cursor-pointer"
                       >
                         {isEditingEmail ? <X className="h-4 w-4" /> : <Pencil className="h-4 w-4" />}
                       </button>
                     </div>
                   </div>
-                </div>
-              </div>
 
-              {/* Personal details */}
-              <div>
-                <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-4 border-b border-border pb-1.5">
-                  {t('profile.sections.personal')}
-                </h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {/* Display Name */}
                   <div>
-                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="displayName">
+                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="account-display-name">
                       {t('profile.fields.displayName')}
                     </label>
-                    <div className="relative">
-                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground">
+                    <div className="relative flex items-center">
+                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
                         <Edit2 className="h-4 w-4" />
                       </span>
                       <input
-                        id="displayName"
+                        id="account-display-name"
                         type="text"
                         value={displayName}
                         onChange={e => setDisplayName(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full pl-9 pr-4 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50"
+                        placeholder="John Doe"
+                        className="w-full pl-9 pr-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
                       />
                     </div>
                   </div>
 
+                  {/* Preferred Language */}
                   <div>
-                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="birthDay">
-                      {t('profile.fields.birthday')}
+                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="account-language">
+                      {t('profile.fields.language')}
                     </label>
-                    <div className="grid grid-cols-3 gap-2">
+                    <div className="relative flex items-center">
+                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
+                        <Globe className="h-4 w-4" />
+                      </span>
                       <select
-                        id="birthDay"
-                        value={birthDay}
-                        onChange={e => setBirthDay(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full px-3 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50 cursor-pointer"
+                        id="account-language"
+                        value={preferredLanguage}
+                        onChange={e => setPreferredLanguage(e.target.value)}
+                        className="w-full pl-9 pr-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
                       >
-                        <option value="">{t('common.day')}</option>
-                        {days.map(d => (
-                          <option key={d} value={d}>
-                            {d}
-                          </option>
-                        ))}
-                      </select>
-
-                      <select
-                        id="birthMonth"
-                        value={birthMonth}
-                        onChange={e => setBirthMonth(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full px-3 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50 cursor-pointer"
-                      >
-                        <option value="">{t('common.month')}</option>
-                        {months.map(m => (
-                          <option key={m.value} value={m.value}>
-                            {m.label}
-                          </option>
-                        ))}
-                      </select>
-
-                      <select
-                        id="birthYear"
-                        value={birthYear}
-                        onChange={e => setBirthYear(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full px-3 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50 cursor-pointer"
-                      >
-                        <option value="">{t('common.year')}</option>
-                        {years.map(y => (
-                          <option key={y} value={y}>
-                            {y}
-                          </option>
-                        ))}
+                        <option value="en">English (US)</option>
+                        <option value="pt">Português (BR)</option>
+                        <option value="es">Español</option>
                       </select>
                     </div>
-                    {birthday && (
-                      <p className="text-xs text-muted-foreground mt-1.5 pl-1">
-                        {t('profile.fields.birthday')}: <span className="font-medium text-foreground">{formatDate(birthday)}</span>
-                      </p>
-                    )}
                   </div>
 
+                  {/* Submit Button */}
+                  <div className="flex justify-end pt-4 border-t border-border">
+                    <button
+                      type="submit"
+                      disabled={isSavingAccount}
+                      className="px-6 py-2.5 rounded-lg bg-primary hover:bg-primary/95 text-primary-foreground font-semibold text-sm transition-all cursor-pointer flex items-center gap-2 disabled:opacity-50 shadow-xs"
+                    >
+                      {isSavingAccount ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <span>{t('common.saving')}</span>
+                        </>
+                      ) : (
+                        <span>{t('common.save')}</span>
+                      )}
+                    </button>
+                  </div>
+                </form>
+              </div>
+            )}
+
+            {/* TAB 2: Personal Details */}
+            {activeTab === 'personal' && (
+              <div 
+                id="panel-personal" 
+                role="tabpanel" 
+                aria-labelledby="tab-personal"
+                className="bg-card border border-border rounded-xl p-6 shadow-xs animate-in fade-in-50 duration-200"
+              >
+                <div className="flex items-center gap-3 mb-6 pb-4 border-b border-border">
+                  <div className="p-2 rounded-lg bg-primary/10 text-primary">
+                    <Activity className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <h3 className="text-base font-semibold text-foreground">{t('profile.tabs.personal')}</h3>
+                    <p className="text-xs text-muted-foreground">{t('profile.sections.physical')}</p>
+                  </div>
+                </div>
+
+                {personalSuccess && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-xs animate-in fade-in duration-200">
+                    <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{t('profile.successMsg')}</span>
+                  </div>
+                )}
+
+                {personalError && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-destructive/10 border border-destructive/25 text-destructive rounded-lg text-xs">
+                    <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{personalError}</span>
+                  </div>
+                )}
+
+                <form onSubmit={handleSavePersonal} className="space-y-6">
+                  {/* Birthday and Real-Time Age */}
+                  <div>
+                    <div className="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+                      <div className="md:col-span-3">
+                        <label className="block text-sm font-medium text-foreground mb-1.5">
+                          {t('profile.fields.birthday')}
+                        </label>
+                        <div className="grid grid-cols-3 gap-2">
+                          <select
+                            id="birthday-month"
+                            aria-label={t('profile.fields.birthday')}
+                            value={birthMonth}
+                            onChange={e => setBirthMonth(e.target.value)}
+                            className="w-full px-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                          >
+                            <option value="">{i18n.language === 'pt' ? 'Mês' : i18n.language === 'es' ? 'Mes' : 'Month'}</option>
+                            {months.map(m => (
+                              <option key={m.value} value={m.value}>{m.label}</option>
+                            ))}
+                          </select>
+
+                          <select
+                            id="birthday-day"
+                            aria-label={t('profile.fields.birthday')}
+                            value={birthDay}
+                            onChange={e => setBirthDay(e.target.value)}
+                            className="w-full px-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                          >
+                            <option value="">{i18n.language === 'pt' ? 'Dia' : i18n.language === 'es' ? 'Día' : 'Day'}</option>
+                            {days.map(d => (
+                              <option key={d} value={d}>{d}</option>
+                            ))}
+                          </select>
+
+                          <select
+                            id="birthday-year"
+                            aria-label={t('profile.fields.birthday')}
+                            value={birthYear}
+                            onChange={e => setBirthYear(e.target.value)}
+                            className="w-full px-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                          >
+                            <option value="">{i18n.language === 'pt' ? 'Ano' : i18n.language === 'es' ? 'Año' : 'Year'}</option>
+                            {years.map(y => (
+                              <option key={y} value={y}>{y}</option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      {/* Read-Only Calculated Age Field */}
+                      <div className="md:col-span-1">
+                        <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="personal-age">
+                          {t('profile.fields.age')}
+                        </label>
+                        <input
+                          id="personal-age"
+                          type="text"
+                          readOnly
+                          value={ageDisplay}
+                          className="w-full px-3 py-2.5 rounded-lg border border-input bg-muted/50 text-foreground font-medium text-sm cursor-not-allowed select-none text-center"
+                          title={t('profile.fields.age')}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Gender Selector */}
                   <div>
                     <label className="block text-sm font-medium text-foreground mb-1.5">
                       {t('profile.fields.gender')}
                     </label>
-                    <div className="grid grid-cols-2 gap-4">
+                    <div className="grid grid-cols-2 gap-3">
                       <button
                         type="button"
                         onClick={() => setGender('male')}
-                        disabled={isLoading}
-                        className={`py-2 rounded-lg border font-medium text-sm transition-all cursor-pointer ${
-                          gender === 'male'
-                            ? 'border-primary bg-primary/10 text-primary shadow-xs'
-                            : 'border-input bg-background text-muted-foreground hover:bg-muted'
+                        className={`py-2.5 px-4 rounded-lg border text-sm font-medium transition-colors cursor-pointer flex items-center justify-center gap-2 ${
+                          gender === 'male' 
+                            ? 'bg-primary/10 border-primary text-primary font-semibold' 
+                            : 'border-input hover:bg-muted text-muted-foreground'
                         }`}
                       >
-                        {t('common.male')}
+                        <span>👨 {i18n.language === 'pt' ? 'Masculino' : i18n.language === 'es' ? 'Masculino' : 'Male'}</span>
                       </button>
                       <button
                         type="button"
                         onClick={() => setGender('female')}
-                        disabled={isLoading}
-                        className={`py-2 rounded-lg border font-medium text-sm transition-all cursor-pointer ${
-                          gender === 'female'
-                            ? 'border-primary bg-primary/10 text-primary shadow-xs'
-                            : 'border-input bg-background text-muted-foreground hover:bg-muted'
+                        className={`py-2.5 px-4 rounded-lg border text-sm font-medium transition-colors cursor-pointer flex items-center justify-center gap-2 ${
+                          gender === 'female' 
+                            ? 'bg-primary/10 border-primary text-primary font-semibold' 
+                            : 'border-input hover:bg-muted text-muted-foreground'
                         }`}
                       >
-                        {t('common.female')}
+                        <span>👩 {i18n.language === 'pt' ? 'Feminino' : i18n.language === 'es' ? 'Femenino' : 'Female'}</span>
                       </button>
                     </div>
                   </div>
 
+                  {/* Height and Target Weight */}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="personal-height">
+                        {t('profile.fields.height')}
+                      </label>
+                      <div className="relative flex items-center">
+                        <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
+                          <Ruler className="h-4 w-4" />
+                        </span>
+                        <input
+                          id="personal-height"
+                          type="number"
+                          step="0.1"
+                          min="50"
+                          max="250"
+                          value={heightCm}
+                          onChange={e => setHeightCm(e.target.value)}
+                          placeholder="175"
+                          className="w-full pl-9 pr-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="personal-weight">
+                        {t('profile.fields.weight')}
+                      </label>
+                      <div className="relative flex items-center">
+                        <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
+                          <Weight className="h-4 w-4" />
+                        </span>
+                        <input
+                          id="personal-weight"
+                          type="number"
+                          step="0.1"
+                          min="20"
+                          max="300"
+                          value={targetWeightKg}
+                          onChange={e => setTargetWeightKg(e.target.value)}
+                          placeholder="70.0"
+                          className="w-full pl-9 pr-3 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Submit Button */}
+                  <div className="flex justify-end pt-4 border-t border-border">
+                    <button
+                      type="submit"
+                      disabled={isSavingPersonal}
+                      className="px-6 py-2.5 rounded-lg bg-primary hover:bg-primary/95 text-primary-foreground font-semibold text-sm transition-all cursor-pointer flex items-center gap-2 disabled:opacity-50 shadow-xs"
+                    >
+                      {isSavingPersonal ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <span>{t('common.saving')}</span>
+                        </>
+                      ) : (
+                        <span>{t('common.save')}</span>
+                      )}
+                    </button>
+                  </div>
+                </form>
+              </div>
+            )}
+
+            {/* TAB 3: Security */}
+            {activeTab === 'security' && (
+              <div 
+                id="panel-security" 
+                role="tabpanel" 
+                aria-labelledby="tab-security"
+                className="bg-card border border-border rounded-xl p-6 shadow-xs animate-in fade-in-50 duration-200"
+              >
+                <div className="flex items-center gap-3 mb-6 pb-4 border-b border-border">
+                  <div className="p-2 rounded-lg bg-primary/10 text-primary">
+                    <KeyRound className="h-5 w-5" />
+                  </div>
                   <div>
-                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="preferredLanguage">
-                      {t('profile.fields.language')}
+                    <h3 className="text-base font-semibold text-foreground">{t('profile.security.title')}</h3>
+                    <p className="text-xs text-muted-foreground">{t('profile.security.subtitle')}</p>
+                  </div>
+                </div>
+
+                {securitySuccess && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-xs animate-in fade-in duration-200">
+                    <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{t('profile.security.passwordChangedSuccess')}</span>
+                  </div>
+                )}
+
+                {securityError && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-destructive/10 border border-destructive/25 text-destructive rounded-lg text-xs">
+                    <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{securityError}</span>
+                  </div>
+                )}
+
+                <form onSubmit={handleSaveSecurity} className="space-y-4">
+                  {/* Current Password */}
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="current-password">
+                      {t('profile.security.currentPassword')}
                     </label>
                     <div className="relative">
-                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground">
-                        <Globe className="h-4 w-4" />
+                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
+                        <Lock className="h-4 w-4" />
                       </span>
-                      <select
-                        id="preferredLanguage"
-                        value={preferredLanguage}
-                        onChange={e => setPreferredLanguage(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full pl-9 pr-4 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50 appearance-none cursor-pointer"
+                      <input
+                        id="current-password"
+                        type={showCurrentPassword ? 'text' : 'password'}
+                        value={currentPassword}
+                        onChange={e => setCurrentPassword(e.target.value)}
+                        placeholder={t('profile.security.currentPasswordPlaceholder')}
+                        required
+                        className="w-full pl-9 pr-10 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                        className="absolute right-3 top-3 text-muted-foreground hover:text-foreground cursor-pointer"
+                        tabIndex={-1}
                       >
-                        <option value="en">🇺🇸 English</option>
-                        <option value="pt">🇧🇷 Português</option>
-                        <option value="es">🇪🇸 Español</option>
-                      </select>
+                        {showCurrentPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
                     </div>
+                  </div>
+
+                  {/* New Password */}
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="new-password">
+                      {t('profile.security.newPassword')}
+                    </label>
+                    <div className="relative">
+                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
+                        <Lock className="h-4 w-4" />
+                      </span>
+                      <input
+                        id="new-password"
+                        type={showNewPassword ? 'text' : 'password'}
+                        value={newPassword}
+                        onChange={e => setNewPassword(e.target.value)}
+                        placeholder={t('profile.security.newPasswordPlaceholder')}
+                        required
+                        minLength={6}
+                        className="w-full pl-9 pr-10 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowNewPassword(!showNewPassword)}
+                        className="absolute right-3 top-3 text-muted-foreground hover:text-foreground cursor-pointer"
+                        tabIndex={-1}
+                      >
+                        {showNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Confirm New Password */}
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="confirm-new-password">
+                      {t('profile.security.confirmPassword')}
+                    </label>
+                    <div className="relative">
+                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground pointer-events-none">
+                        <Lock className="h-4 w-4" />
+                      </span>
+                      <input
+                        id="confirm-new-password"
+                        type={showConfirmNewPassword ? 'text' : 'password'}
+                        value={confirmNewPassword}
+                        onChange={e => setConfirmNewPassword(e.target.value)}
+                        placeholder={t('profile.security.confirmPasswordPlaceholder')}
+                        required
+                        minLength={6}
+                        className="w-full pl-9 pr-10 py-2.5 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-primary"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowConfirmNewPassword(!showConfirmNewPassword)}
+                        className="absolute right-3 top-3 text-muted-foreground hover:text-foreground cursor-pointer"
+                        tabIndex={-1}
+                      >
+                        {showConfirmNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Submit Button */}
+                  <div className="flex justify-end pt-4 border-t border-border">
+                    <button
+                      type="submit"
+                      disabled={isSavingSecurity || !currentPassword || !newPassword || !confirmNewPassword}
+                      className="px-6 py-2.5 rounded-lg bg-primary hover:bg-primary/95 text-primary-foreground font-semibold text-sm transition-all cursor-pointer flex items-center gap-2 disabled:opacity-50 shadow-xs"
+                    >
+                      {isSavingSecurity ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <span>{t('common.saving')}</span>
+                        </>
+                      ) : (
+                        <span>{t('profile.security.changePasswordBtn')}</span>
+                      )}
+                    </button>
+                  </div>
+                </form>
+              </div>
+            )}
+
+            {/* TAB 4: Privacy & Data Management */}
+            {activeTab === 'privacy' && (
+              <div 
+                id="panel-privacy" 
+                role="tabpanel" 
+                aria-labelledby="tab-privacy"
+                className="bg-card border border-border rounded-xl p-6 shadow-xs animate-in fade-in-50 duration-200"
+              >
+                <div className="flex items-center gap-3 mb-6 pb-4 border-b border-border">
+                  <div className="p-2 rounded-lg bg-destructive/10 text-destructive">
+                    <Shield className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <h3 className="text-base font-semibold text-foreground">{t('profile.dataManagement.title')}</h3>
+                    <p className="text-xs text-muted-foreground">{t('profile.dataManagement.subtitle')}</p>
+                  </div>
+                </div>
+
+                {deleteDataSuccess && (
+                  <div className="mb-6 flex items-start gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-xs animate-in fade-in duration-200">
+                    <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>{deleteDataSuccess}</span>
+                  </div>
+                )}
+
+                <div className="space-y-6">
+                  {/* Option A: Delete Health Data */}
+                  <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 rounded-lg border border-border bg-background/50 hover:bg-muted/20 transition-colors">
+                    <div className="space-y-1 max-w-xl">
+                      <h4 className="text-sm font-semibold text-foreground flex items-center gap-2">
+                        <Trash2 className="h-4 w-4 text-amber-500" />
+                        {t('profile.dataManagement.deleteDataTitle')}
+                      </h4>
+                      <p className="text-xs text-muted-foreground leading-relaxed">
+                        {t('profile.dataManagement.deleteDataDesc')}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDeleteDataPassword('');
+                        setDeleteDataError(null);
+                        setShowDeleteDataModal(true);
+                      }}
+                      className="px-4 py-2 rounded-lg border border-amber-500/40 hover:border-amber-500 hover:bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-semibold whitespace-nowrap transition-all cursor-pointer shadow-xs self-start sm:self-center"
+                    >
+                      {t('profile.dataManagement.deleteDataBtn')}
+                    </button>
+                  </div>
+
+                  {/* Option B: Delete Account */}
+                  <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 rounded-lg border border-destructive/25 bg-destructive/5 hover:bg-destructive/10 transition-colors">
+                    <div className="space-y-1 max-w-xl">
+                      <h4 className="text-sm font-semibold text-destructive flex items-center gap-2">
+                        <AlertTriangle className="h-4 w-4 text-destructive" />
+                        {t('profile.dataManagement.deleteAccountTitle')}
+                      </h4>
+                      <p className="text-xs text-muted-foreground leading-relaxed">
+                        {t('profile.dataManagement.deleteAccountDesc')}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDeleteAccountPassword('');
+                        setDeleteAccountError(null);
+                        setShowDeleteAccountModal(true);
+                      }}
+                      className="px-4 py-2 rounded-lg bg-destructive hover:bg-destructive/90 text-destructive-foreground text-xs font-semibold whitespace-nowrap transition-all cursor-pointer shadow-xs self-start sm:self-center"
+                    >
+                      {t('profile.dataManagement.deleteAccountBtn')}
+                    </button>
                   </div>
                 </div>
               </div>
+            )}
 
-              {/* Physical specifications */}
-              <div>
-                <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-4 border-b border-border pb-1.5">
-                  {t('profile.sections.physical')}
-                </h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="heightCm">
-                      {t('profile.fields.height')}
-                    </label>
-                    <div className="relative">
-                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground">
-                        <Ruler className="h-4 w-4" />
-                      </span>
-                      <input
-                        id="heightCm"
-                        type="number"
-                        step="0.1"
-                        value={heightCm}
-                        onChange={e => setHeightCm(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full pl-9 pr-4 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50"
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1.5" htmlFor="targetWeightKg">
-                      {t('profile.fields.weight')}
-                    </label>
-                    <div className="relative">
-                      <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-muted-foreground">
-                        <Weight className="h-4 w-4" />
-                      </span>
-                      <input
-                        id="targetWeightKg"
-                        type="number"
-                        step="0.1"
-                        value={targetWeightKg}
-                        onChange={e => setTargetWeightKg(e.target.value)}
-                        disabled={isLoading}
-                        className="w-full pl-9 pr-4 py-2 rounded-lg border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all disabled:opacity-50"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex justify-end pt-4 border-t border-border">
-                <button
-                  type="submit"
-                  disabled={isLoading}
-                  className="px-6 py-2.5 rounded-lg bg-primary hover:bg-primary/95 text-primary-foreground font-semibold text-sm transition-all cursor-pointer flex items-center gap-2 disabled:opacity-50 shadow-xs"
-                >
-                  {isLoading ? (
-                    <>
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      <span>{t('common.saving')}</span>
-                    </>
-                  ) : (
-                    <span>{t('common.save')}</span>
-                  )}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-
-        {/* Data Management & Privacy Section (GDPR / LGPD Compliance) */}
-        <div className="bg-card border border-border rounded-xl p-6 shadow-xs">
-          <div className="flex items-center gap-3 mb-4 pb-3 border-b border-border">
-            <div className="p-2 rounded-lg bg-destructive/10 text-destructive">
-              <Shield className="h-5 w-5" />
-            </div>
-            <div>
-              <h2 className="text-base font-semibold text-foreground">{t('profile.dataManagement.title')}</h2>
-              <p className="text-xs text-muted-foreground">{t('profile.dataManagement.subtitle')}</p>
-            </div>
-          </div>
-
-          {deleteDataSuccess && (
-            <div className="mb-6 flex items-start gap-2 p-3 bg-emerald-500/10 border border-emerald-500/25 text-emerald-600 dark:text-emerald-400 rounded-lg text-xs animate-in fade-in duration-200">
-              <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
-              <span>{deleteDataSuccess}</span>
-            </div>
-          )}
-
-          <div className="space-y-6">
-            {/* Option A: Delete Health Data */}
-            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 rounded-lg border border-border bg-background/50 hover:bg-muted/20 transition-colors">
-              <div className="space-y-1 max-w-xl">
-                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
-                  <Trash2 className="h-4 w-4 text-amber-500" />
-                  {t('profile.dataManagement.deleteDataTitle')}
-                </h3>
-                <p className="text-xs text-muted-foreground leading-relaxed">
-                  {t('profile.dataManagement.deleteDataDesc')}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => {
-                  setDeleteDataPassword('');
-                  setDeleteDataError(null);
-                  setShowDeleteDataModal(true);
-                }}
-                className="px-4 py-2 rounded-lg border border-amber-500/40 hover:border-amber-500 hover:bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-semibold whitespace-nowrap transition-all cursor-pointer shadow-xs self-start sm:self-center"
-              >
-                {t('profile.dataManagement.deleteDataBtn')}
-              </button>
-            </div>
-
-            {/* Option B: Delete Account */}
-            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 rounded-lg border border-destructive/25 bg-destructive/5 hover:bg-destructive/10 transition-colors">
-              <div className="space-y-1 max-w-xl">
-                <h3 className="text-sm font-semibold text-destructive flex items-center gap-2">
-                  <AlertTriangle className="h-4 w-4 text-destructive" />
-                  {t('profile.dataManagement.deleteAccountTitle')}
-                </h3>
-                <p className="text-xs text-muted-foreground leading-relaxed">
-                  {t('profile.dataManagement.deleteAccountDesc')}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => {
-                  setDeleteAccountPassword('');
-                  setDeleteAccountError(null);
-                  setShowDeleteAccountModal(true);
-                }}
-                className="px-4 py-2 rounded-lg bg-destructive hover:bg-destructive/90 text-destructive-foreground text-xs font-semibold whitespace-nowrap transition-all cursor-pointer shadow-xs self-start sm:self-center"
-              >
-                {t('profile.dataManagement.deleteAccountBtn')}
-              </button>
-            </div>
           </div>
         </div>
 

--- a/frontend/src/views/__tests__/ProfileDeletion.test.tsx
+++ b/frontend/src/views/__tests__/ProfileDeletion.test.tsx
@@ -67,6 +67,10 @@ describe('Profile Data Deletion and Account Removal', () => {
   it('renders the Data Management & Privacy section with both deletion options', () => {
     render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
 
+    // Switch to Privacy tab
+    const privacyTab = screen.getAllByRole('tab', { name: /Privacy/i })[0];
+    fireEvent.click(privacyTab);
+
     expect(screen.getByText('Data Management & Privacy')).toBeInTheDocument();
     expect(screen.getByText('Delete Health & Workout Data')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete My Data' })).toBeInTheDocument();
@@ -81,6 +85,10 @@ describe('Profile Data Deletion and Account Removal', () => {
     });
 
     render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Privacy tab
+    const privacyTab = screen.getAllByRole('tab', { name: /Privacy/i })[0];
+    fireEvent.click(privacyTab);
 
     // Open Delete Data Modal
     fireEvent.click(screen.getByRole('button', { name: 'Delete My Data' }));
@@ -106,6 +114,10 @@ describe('Profile Data Deletion and Account Removal', () => {
 
     render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
 
+    // Switch to Privacy tab
+    const privacyTab = screen.getAllByRole('tab', { name: /Privacy/i })[0];
+    fireEvent.click(privacyTab);
+
     // Open Delete Data Modal
     fireEvent.click(screen.getByRole('button', { name: 'Delete My Data' }));
 
@@ -125,6 +137,10 @@ describe('Profile Data Deletion and Account Removal', () => {
     const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
 
     render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Privacy tab
+    const privacyTab = screen.getAllByRole('tab', { name: /Privacy/i })[0];
+    fireEvent.click(privacyTab);
 
     // Open Delete Account Modal
     fireEvent.click(screen.getByRole('button', { name: 'Delete Account' }));

--- a/frontend/src/views/__tests__/ProfileTabs.test.tsx
+++ b/frontend/src/views/__tests__/ProfileTabs.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Profile from '../Profile';
+import { api } from '../../lib/api';
+import type { User } from '../../lib/api';
+import enTranslations from '../../locales/en.json';
+
+function getTranslation(obj: any, path: string): string {
+  const parts = path.split('.');
+  let current = obj;
+  for (const part of parts) {
+    if (current === undefined || current === null) return path;
+    current = current[part];
+  }
+  return typeof current === 'string' ? current : path;
+}
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: any) => {
+        if (key === 'profile.fields.ageUnit') {
+          return `${options?.count} years`;
+        }
+        if (options?.email) {
+          return key.replace('{{email}}', options.email);
+        }
+        return getTranslation(enTranslations, key) || key;
+      },
+      i18n: { language: 'en' },
+    }),
+  };
+});
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    updateProfile: vi.fn(),
+    uploadProfilePicture: vi.fn(),
+    changePassword: vi.fn(),
+    deleteUserData: vi.fn(),
+    deleteAccount: vi.fn(),
+    getMe: vi.fn(),
+  },
+}));
+
+describe('Profile Tabbed Navigation and Functionality', () => {
+  const mockUser: User = {
+    id: 1,
+    email: 'testuser@example.com',
+    display_name: 'Tab Tester',
+    gender: 'male',
+    birthday: '1990-05-15',
+    height_cm: 180,
+    target_weight_kg: 75,
+    profile_image_path: null,
+    profile_image_url: null,
+    preferred_language: 'en',
+    email_confirmed: true,
+    pending_email: null,
+    created_at: '2026-01-01T00:00:00Z',
+  };
+
+  const mockOnProfileUpdated = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all 4 tabs and defaults to Account Information', () => {
+    render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    const accountTabs = screen.getAllByRole('tab', { name: /Account Information/i });
+    expect(accountTabs.length).toBeGreaterThanOrEqual(1);
+
+    const personalTabs = screen.getAllByRole('tab', { name: /Personal Details/i });
+    expect(personalTabs.length).toBeGreaterThanOrEqual(1);
+
+    const securityTabs = screen.getAllByRole('tab', { name: /Security/i });
+    expect(securityTabs.length).toBeGreaterThanOrEqual(1);
+
+    const privacyTabs = screen.getAllByRole('tab', { name: /Privacy/i });
+    expect(privacyTabs.length).toBeGreaterThanOrEqual(1);
+
+    // Default active panel is Account Information
+    expect(screen.getByRole('tabpanel', { name: /Account Information/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Display Name')).toHaveValue('Tab Tester');
+  });
+
+  it('switches to Personal Details tab and calculates age in real-time', () => {
+    const { container } = render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Personal Details
+    const personalTab = screen.getAllByRole('tab', { name: /Personal Details/i })[0];
+    fireEvent.click(personalTab);
+
+    expect(screen.getByRole('tabpanel', { name: /Personal Details/i })).toBeInTheDocument();
+
+    // Check calculated age input field (1990 birth year -> 36 in 2026)
+    const ageInput = screen.getByLabelText('Age');
+    expect(ageInput).toBeInTheDocument();
+    expect(ageInput).toHaveValue('36 years');
+
+    // Change birth year to 2000
+    const yearSelect = container.querySelector('#birthday-year') as HTMLSelectElement;
+    expect(yearSelect).toBeInTheDocument();
+    fireEvent.change(yearSelect, { target: { value: '2000' } });
+
+    expect(ageInput).toHaveValue('26 years');
+  });
+
+  it('saves changes in Account Information tab', async () => {
+    (api.updateProfile as any).mockResolvedValueOnce({
+      ...mockUser,
+      display_name: 'Updated Name',
+    });
+
+    render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    const nameInput = screen.getByLabelText('Display Name');
+    fireEvent.change(nameInput, { target: { value: 'Updated Name' } });
+
+    const saveBtn = screen.getByRole('button', { name: /Save Settings/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(api.updateProfile).toHaveBeenCalledWith({
+        display_name: 'Updated Name',
+        preferred_language: 'en',
+      });
+      expect(mockOnProfileUpdated).toHaveBeenCalled();
+    });
+  });
+
+  it('saves changes in Personal Details tab', async () => {
+    (api.updateProfile as any).mockResolvedValueOnce({
+      ...mockUser,
+      height_cm: 185,
+    });
+
+    render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Personal tab
+    const personalTab = screen.getAllByRole('tab', { name: /Personal Details/i })[0];
+    fireEvent.click(personalTab);
+
+    const heightInput = screen.getByLabelText('Height (cm)');
+    fireEvent.change(heightInput, { target: { value: '185' } });
+
+    const saveBtn = screen.getByRole('button', { name: /Save Settings/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(api.updateProfile).toHaveBeenCalledWith(expect.objectContaining({
+        height_cm: 185,
+      }));
+    });
+  });
+
+  it('validates password mismatch in Security tab', async () => {
+    render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Security tab
+    const securityTab = screen.getAllByRole('tab', { name: /Security/i })[0];
+    fireEvent.click(securityTab);
+
+    expect(screen.getByRole('tabpanel', { name: /Security/i })).toBeInTheDocument();
+
+    const currentPwd = screen.getByLabelText('Current Password');
+    const newPwd = screen.getByLabelText('New Password');
+    const confirmPwd = screen.getByLabelText('Confirm New Password');
+
+    fireEvent.change(currentPwd, { target: { value: 'current123' } });
+    fireEvent.change(newPwd, { target: { value: 'newpassword123' } });
+    fireEvent.change(confirmPwd, { target: { value: 'different123' } });
+
+    const submitBtn = screen.getByRole('button', { name: 'Update Password' });
+    fireEvent.click(submitBtn);
+
+    expect(screen.getByText('New password and confirmation do not match')).toBeInTheDocument();
+    expect(api.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('successfully updates password in Security tab', async () => {
+    (api.changePassword as any).mockResolvedValueOnce({
+      message: 'Password changed successfully',
+    });
+
+    render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Security tab
+    const securityTab = screen.getAllByRole('tab', { name: /Security/i })[0];
+    fireEvent.click(securityTab);
+
+    const currentPwd = screen.getByLabelText('Current Password');
+    const newPwd = screen.getByLabelText('New Password');
+    const confirmPwd = screen.getByLabelText('Confirm New Password');
+
+    fireEvent.change(currentPwd, { target: { value: 'current123' } });
+    fireEvent.change(newPwd, { target: { value: 'newpassword123' } });
+    fireEvent.change(confirmPwd, { target: { value: 'newpassword123' } });
+
+    const submitBtn = screen.getByRole('button', { name: 'Update Password' });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(api.changePassword).toHaveBeenCalledWith('current123', 'newpassword123');
+      expect(screen.getByText('Your password has been changed successfully!')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to Privacy tab and displays data deletion options', () => {
+    render(<Profile user={mockUser} onProfileUpdated={mockOnProfileUpdated} />);
+
+    // Switch to Privacy tab
+    const privacyTab = screen.getAllByRole('tab', { name: /Privacy/i })[0];
+    fireEvent.click(privacyTab);
+
+    expect(screen.getByRole('tabpanel', { name: /Privacy/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete My Data' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Account' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Overview
Improves the User Profile settings interface by moving account settings into an accessible tabbed layout for clearer separation of concerns.

## Key Changes
- **Tabbed Layout**:
  - **Account Information**: Display Name, Email (with edit and OTP verification flow), Preferred Language.
  - **Personal Details**: Birthday pickers, dynamic read-only **Age** calculation, Gender, Height, and Target Weight.
  - **Security**: In-app **Change Password** flow with validation and email confirmation.
  - **Privacy**: Controls for user data deletion (Option A) and account removal (Option B).
- **Backend**:
  - Added POST /api/users/change-password endpoint with password validation, hash updating, audit logging, and confirmation email.
  - Unit/integration tests in backend/tests/test_change_password.py.
- **Frontend**:
  - Added changePassword API client method in frontend/src/lib/api.ts.
  - Added full translation keys across en.json, pt.json, and es.json.
  - ARIA tab accessibility (role=tablist, role=tab, role=tabpanel) and keyboard navigation.
  - Component tests in frontend/src/views/__tests__/ProfileTabs.test.tsx.

## Verification
- uv run python -m pytest -> 25 passed
- npm run lint -> 0 errors
- npm run test:run -> 14 suites passed (52 tests)
- npm run build -> Passed

Closes #47