### PR TITLE
feat(docs): disable Swagger and OpenAPI endpoints in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 Thumbs.db
 *.local
-.env
+*.env
 
 # Database files
 *.db

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -121,6 +121,7 @@ Regardless of the method chosen, you must configure the environment variables un
 | `MAILGUN_DOMAIN` | *(None)* | **[OPTIONAL]** Mailgun sending domain (e.g. `mg.yourdomain.com` or `sandboxXXXXXXXX.mailgun.org`). |
 | `MAILGUN_API_BASE_URL` | `https://api.mailgun.net/v3` | Mailgun API base URL. Use `https://api.mailgun.net/v3` for US region or `https://api.eu.mailgun.net/v3` for EU region. |
 | `MAIL_FROM_ADDRESS` | `FitdaysWeb <noreply@fitdays.app>` | The `From` header address for outgoing verification emails. |
+| `ENVIRONMENT` | `production` | Application runtime environment (`development` or `production`). Setting to `production` disables Swagger/OpenAPI interactive documentation endpoints (`/docs`, `/redoc`, `/openapi.json`) for enhanced security. |
 | `FRONTEND_URL` | `http://localhost` | **[CRITICAL IN PRODUCTION]** The public URL of the frontend (e.g. `https://fitdays.yourdomain.com`). Used to construct 1-click email confirmation links. |
 
 ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,10 +25,16 @@ os.makedirs(UPLOAD_DIR, exist_ok=True)
 REPORTS_DIR = os.getenv("REPORTS_DIR", os.path.join(backend_dir, "uploads", "reports"))
 os.makedirs(REPORTS_DIR, exist_ok=True)
 
+ENVIRONMENT = os.getenv("ENVIRONMENT", os.getenv("ENV", "development")).lower()
+IS_PRODUCTION = ENVIRONMENT in ("production", "prod")
+
 app = FastAPI(
     title="FitdaysWeb API",
     description="Backend service for importing, analyzing, and serving Fitdays body composition data",
-    version="0.1.0"
+    version="0.1.0",
+    docs_url=None if IS_PRODUCTION else "/docs",
+    redoc_url=None if IS_PRODUCTION else "/redoc",
+    openapi_url=None if IS_PRODUCTION else "/openapi.json",
 )
 
 # Configure CORS for decoupled React frontend
@@ -51,4 +57,6 @@ app.include_router(shared_links.router)
 
 @app.get("/")
 def read_root():
+    if IS_PRODUCTION:
+        return {"message": "Welcome to FitdaysWeb API."}
     return {"message": "Welcome to FitdaysWeb API. Visit /docs for Swagger documentation."}

--- a/backend/tests/test_docs_environment.py
+++ b/backend/tests/test_docs_environment.py
@@ -1,0 +1,52 @@
+import os
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+def test_docs_enabled_in_development():
+    # Ensure environment is development
+    os.environ["ENVIRONMENT"] = "development"
+    import app.main
+    importlib.reload(app.main)
+
+    client = TestClient(app.main.app)
+
+    # In development, docs and openapi should be accessible
+    docs_resp = client.get("/docs")
+    assert docs_resp.status_code == 200
+
+    openapi_resp = client.get("/openapi.json")
+    assert openapi_resp.status_code == 200
+    assert "openapi" in openapi_resp.json()
+
+    root_resp = client.get("/")
+    assert root_resp.status_code == 200
+    assert "Visit /docs" in root_resp.json()["message"]
+
+
+def test_docs_disabled_in_production():
+    # Set environment to production
+    os.environ["ENVIRONMENT"] = "production"
+    import app.main
+    importlib.reload(app.main)
+
+    client = TestClient(app.main.app)
+
+    # In production, docs, redoc, and openapi should return 404
+    docs_resp = client.get("/docs")
+    assert docs_resp.status_code == 404
+
+    redoc_resp = client.get("/redoc")
+    assert redoc_resp.status_code == 404
+
+    openapi_resp = client.get("/openapi.json")
+    assert openapi_resp.status_code == 404
+
+    root_resp = client.get("/")
+    assert root_resp.status_code == 200
+    assert "Visit /docs" not in root_resp.json()["message"]
+    assert root_resp.json()["message"] == "Welcome to FitdaysWeb API."
+
+    # Restore environment to development
+    os.environ["ENVIRONMENT"] = "development"
+    importlib.reload(app.main)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/cfassoni/fitdaysweb/backend:latest
     container_name: fitdays-backend
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}
       - DATABASE_URL=sqlite:////app/data/fitdays.db
       - UPLOAD_DIR=/app/data/uploads/profile_pics
       - REPORTS_DIR=/app/data/uploads/reports


### PR DESCRIPTION
## Overview
Disables FastAPI interactive API documentation endpoints (/docs, /redoc, /openapi.json) when running in production to minimize attack surface and improve security.

## Key Changes
- **Backend**:
  - Main application checks ENVIRONMENT and ENV environment variables.
  - In production (ENVIRONMENT=production or prod), docs_url, redoc_url, and openapi_url are set to None.
  - In development (default), docs endpoints remain fully accessible.
  - Automated tests added in backend/tests/test_docs_environment.py.
- **Docker Compose & Deployment**:
  - Added ENVIRONMENT=\ to backend service in docker-compose.prod.yml.
  - Documented ENVIRONMENT variable in DEPLOYMENT.md table.

## Verification
- uv run python -m pytest -> 27 passed
- npm run lint -> 0 errors
- npm run test:run -> 14 suites passed (52 tests)
- npm run build -> Passed

Closes #48