### PR TITLE
fix: disable WiP mockup pages by default

### DIFF
--- a/src/app/__tests__/wip_mockups.test.tsx
+++ b/src/app/__tests__/wip_mockups.test.tsx
@@ -17,27 +17,27 @@ describe("WIP Mockup Routes Feature Flag Protection", () => {
     process.env = { ...originalEnv };
   });
 
-  it("calls notFound() for Nutrition page when explicitly disabled with 'false'", () => {
-    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES = "false";
+  it("calls notFound() for Nutrition page by default", () => {
+    delete process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES;
     NutritionMockupPage();
     expect(navigation.notFound).toHaveBeenCalledTimes(1);
   });
 
-  it("calls notFound() for Activities page when explicitly disabled with 'false'", () => {
-    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES = "false";
+  it("calls notFound() for Activities page by default", () => {
+    delete process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES;
     ActivitiesMockupPage();
     expect(navigation.notFound).toHaveBeenCalledTimes(1);
   });
 
-  it("renders Nutrition preview by default", () => {
-    delete process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES;
+  it("renders Nutrition preview when explicitly enabled with 'true'", () => {
+    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES = "true";
     render(<NutritionMockupPage />);
     expect(screen.getByText("Nutrition & Macros")).toBeInTheDocument();
     expect(screen.getByText("Mockup Preview")).toBeInTheDocument();
   });
 
-  it("renders Activities preview by default", () => {
-    delete process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES;
+  it("renders Activities preview when explicitly enabled with 'true'", () => {
+    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES = "true";
     render(<ActivitiesMockupPage />);
     expect(screen.getByText("Workouts & Activities")).toBeInTheDocument();
     expect(screen.getByText("Mockup Preview")).toBeInTheDocument();

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,5 +1,4 @@
 export const isWipPagesEnabled = (): boolean => {
-  // Always enabled by default for testing/previewing unless explicitly disabled
-  if (process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "false") return false;
-  return true;
+  // Disabled by default unless explicitly enabled via environment variable
+  return process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "true";
 };


### PR DESCRIPTION
## Summary

This PR fixes #71 by disabling Work-in-Progress (WiP) mockup routes (/activities and /nutrition) and their sidebar navigation links by default.

### Key Changes
1. src/lib/featureFlags.ts: Changed default so WiP pages are disabled unless NEXT_PUBLIC_ENABLE_WIP_PAGES="true" is explicitly set.
2. src/app/__tests__/wip_mockups.test.tsx: Updated tests to verify default disabled behavior and explicit enable behavior.

Closes #71