### PR TITLE
feat: support runtime toggleable WiP feature flag via server injection

### DIFF
--- a/src/app/(authenticated)/activities/page.tsx
+++ b/src/app/(authenticated)/activities/page.tsx
@@ -2,11 +2,11 @@
 
 import { notFound } from "next/navigation";
 import { Flame, Activity, Dumbbell, Zap, Info } from "lucide-react";
-import { isWipPagesEnabled } from "@/lib/featureFlags";
+import { useAuth } from "@/context/AuthContext";
 
 export default function ActivitiesMockupPage() {
-  const showWipPages = isWipPagesEnabled();
-  if (!showWipPages) {
+  const { enableWipPages } = useAuth();
+  if (!enableWipPages) {
     notFound();
   }
 

--- a/src/app/(authenticated)/nutrition/page.tsx
+++ b/src/app/(authenticated)/nutrition/page.tsx
@@ -2,11 +2,11 @@
 
 import { notFound } from "next/navigation";
 import { UtensilsCrossed, PieChart, Apple, Info } from "lucide-react";
-import { isWipPagesEnabled } from "@/lib/featureFlags";
+import { useAuth } from "@/context/AuthContext";
 
 export default function NutritionMockupPage() {
-  const showWipPages = isWipPagesEnabled();
-  if (!showWipPages) {
+  const { enableWipPages } = useAuth();
+  if (!enableWipPages) {
     notFound();
   }
 

--- a/src/app/__tests__/wip_mockups.test.tsx
+++ b/src/app/__tests__/wip_mockups.test.tsx
@@ -3,41 +3,58 @@ import { render, screen } from "@testing-library/react";
 import NutritionMockupPage from "../(authenticated)/nutrition/page";
 import ActivitiesMockupPage from "../(authenticated)/activities/page";
 import * as navigation from "next/navigation";
+import * as authContext from "@/context/AuthContext";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
   notFound: vi.fn(),
 }));
 
-describe("WIP Mockup Routes Feature Flag Protection", () => {
-  const originalEnv = process.env;
+// Mock @/context/AuthContext
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: vi.fn(() => ({
+    enableWipPages: false,
+  })),
+}));
 
+describe("WIP Mockup Routes Feature Flag Protection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env = { ...originalEnv };
   });
 
   it("calls notFound() for Nutrition page by default", () => {
-    delete process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES;
+    vi.mocked(authContext.useAuth).mockReturnValue({
+      enableWipPages: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
     NutritionMockupPage();
     expect(navigation.notFound).toHaveBeenCalledTimes(1);
   });
 
   it("calls notFound() for Activities page by default", () => {
-    delete process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES;
+    vi.mocked(authContext.useAuth).mockReturnValue({
+      enableWipPages: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
     ActivitiesMockupPage();
     expect(navigation.notFound).toHaveBeenCalledTimes(1);
   });
 
   it("renders Nutrition preview when explicitly enabled with 'true'", () => {
-    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES = "true";
+    vi.mocked(authContext.useAuth).mockReturnValue({
+      enableWipPages: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
     render(<NutritionMockupPage />);
     expect(screen.getByText("Nutrition & Macros")).toBeInTheDocument();
     expect(screen.getByText("Mockup Preview")).toBeInTheDocument();
   });
 
   it("renders Activities preview when explicitly enabled with 'true'", () => {
-    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES = "true";
+    vi.mocked(authContext.useAuth).mockReturnValue({
+      enableWipPages: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
     render(<ActivitiesMockupPage />);
     expect(screen.getByText("Workouts & Activities")).toBeInTheDocument();
     expect(screen.getByText("Mockup Preview")).toBeInTheDocument();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,6 +36,9 @@ export default async function RootLayout({
   const headerStore = await headers();
   const acceptLanguage = headerStore.get("accept-language");
   const initialLang = resolveLanguage(langCookie, acceptLanguage);
+  const enableWipPages =
+    process.env.ENABLE_WIP_PAGES === "true" ||
+    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "true";
 
   return (
     <html
@@ -44,7 +47,9 @@ export default async function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <AuthProvider initialLang={initialLang}>{children}</AuthProvider>
+        <AuthProvider initialLang={initialLang} enableWipPages={enableWipPages}>
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,8 +15,8 @@ import {
   UtensilsCrossed,
   Flame,
 } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
 import Version from "./Version";
-import { isWipPagesEnabled } from "@/lib/featureFlags";
 
 interface SidebarProps {
   isMobileOpen: boolean;
@@ -31,9 +31,10 @@ export default function Sidebar({
 }: SidebarProps) {
   const { t } = useTranslation();
   const pathname = usePathname();
+  const { enableWipPages } = useAuth();
   const [isCollapsed, setIsCollapsed] = useState(false);
 
-  const showWipPages = isWipPagesEnabled();
+  const showWipPages = enableWipPages;
 
   const navItems = [
     { id: "dashboard", href: "/dashboard", icon: LayoutDashboard },

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -18,10 +18,21 @@ vi.mock("react-i18next", () => ({
         "sidebar.import": "Import CSV Data",
         "sidebar.sharedReports": "Shared Reports",
         "sidebar.closeMenu": "Close Menu",
+        "sidebar.nutrition": "Nutrition",
+        "sidebar.activities": "Activities",
       };
       return translations[key] || key;
     },
   }),
+}));
+
+const mockUseAuth = vi.fn(() => ({
+  enableWipPages: false,
+}));
+
+// Mock @/context/AuthContext
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
 }));
 
 describe("Sidebar Component", () => {
@@ -68,5 +79,23 @@ describe("Sidebar Component", () => {
 
     fireEvent.click(closeButtons[0]);
     expect(mockProps.onMobileClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render WiP items when enableWipPages is false", () => {
+    mockUseAuth.mockReturnValue({ enableWipPages: false });
+    render(<Sidebar {...mockProps} />);
+
+    expect(screen.queryByRole("link", { name: /Nutrition/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Activities/i })).not.toBeInTheDocument();
+  });
+
+  it("renders WiP items when enableWipPages is true", () => {
+    mockUseAuth.mockReturnValue({ enableWipPages: true });
+    render(<Sidebar {...mockProps} />);
+
+    const nutritionLink = screen.getByRole("link", { name: /Nutrition/i });
+    const activitiesLink = screen.getByRole("link", { name: /Activities/i });
+    expect(nutritionLink).toHaveAttribute("href", "/nutrition");
+    expect(activitiesLink).toHaveAttribute("href", "/activities");
   });
 });

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthContextType {
   isCheckingAuth: boolean;
   sharedLinksCount: number;
   setSharedLinksCount: React.Dispatch<React.SetStateAction<number>>;
+  enableWipPages: boolean;
   checkAuth: () => Promise<void>;
   logout: () => void;
 }
@@ -22,9 +23,11 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export function AuthProvider({
   children,
   initialLang,
+  enableWipPages = false,
 }: {
   children: React.ReactNode;
   initialLang?: "en" | "pt" | "es";
+  enableWipPages?: boolean;
 }) {
   const { i18n } = useTranslation();
   const router = useRouter();
@@ -119,6 +122,7 @@ export function AuthProvider({
         isCheckingAuth,
         sharedLinksCount,
         setSharedLinksCount,
+        enableWipPages,
         checkAuth,
         logout,
       }}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,4 +1,7 @@
 export const isWipPagesEnabled = (): boolean => {
   // Disabled by default unless explicitly enabled via environment variable
-  return process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "true";
+  return (
+    process.env.ENABLE_WIP_PAGES === "true" ||
+    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "true"
+  );
 };


### PR DESCRIPTION
## Summary

This PR enables dynamic, zero-rebuild runtime toggling of Work-in-Progress (WiP) feature pages via Docker environment variables (ENABLE_WIP_PAGES or NEXT_PUBLIC_ENABLE_WIP_PAGES).

### Key Implementation Details:
1. **Server-Side Runtime Evaluation:** RootLayout (src/app/layout.tsx) reads process.env.ENABLE_WIP_PAGES and process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES dynamically on every request.
2. **Context Propagation:** Injected into AuthProvider as enableWipPages to supply the value during hydration.
3. **Sidebar & Route Guard:** Sidebar, /activities, and /nutrition check useAuth().enableWipPages dynamically.
4. **Zero Rebuilds:** Changing ENABLE_WIP_PAGES in docker-compose.yml takes effect immediately on container restart.