### PR TITLE
feat(flags): retire NEXT_PUBLIC_ENABLE_WIP_PAGES and enable WiP in dev compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - MAILGUN_API_BASE_URL=${MAILGUN_API_BASE_URL:-https://api.mailgun.net/v3}
       - MAIL_FROM_ADDRESS=${MAIL_FROM_ADDRESS:-Recomp Pro <noreply@recomppro.local>}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost}
+      - ENABLE_WIP_PAGES=true
     volumes:
       # Persistent SQLite database named volume
       - recomp_pro_data:/app/data

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,9 +36,7 @@ export default async function RootLayout({
   const headerStore = await headers();
   const acceptLanguage = headerStore.get("accept-language");
   const initialLang = resolveLanguage(langCookie, acceptLanguage);
-  const enableWipPages =
-    process.env.ENABLE_WIP_PAGES === "true" ||
-    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "true";
+  const enableWipPages = process.env.ENABLE_WIP_PAGES === "true";
 
   return (
     <html

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,7 +1,4 @@
 export const isWipPagesEnabled = (): boolean => {
   // Disabled by default unless explicitly enabled via environment variable
-  return (
-    process.env.ENABLE_WIP_PAGES === "true" ||
-    process.env.NEXT_PUBLIC_ENABLE_WIP_PAGES === "true"
-  );
+  return process.env.ENABLE_WIP_PAGES === "true";
 };


### PR DESCRIPTION
## Summary

This PR standardizes the WiP mockup pages runtime feature flag by retiring the redundant `NEXT_PUBLIC_ENABLE_WIP_PAGES` build-time environment variable completely, relying solely on `ENABLE_WIP_PAGES` evaluated at SSR runtime. It also sets `ENABLE_WIP_PAGES=true` in `docker-compose.yml` for local development.

### Key Changes
1. **Server-Side Flag Evaluation (`src/app/layout.tsx`):**
   - Standardized `layout.tsx` to read only `process.env.ENABLE_WIP_PAGES === "true"`.
2. **Feature Flags Helper (`src/lib/featureFlags.ts`):**
   - Removed `NEXT_PUBLIC_ENABLE_WIP_PAGES` fallback.
3. **Local Dev Environment (`docker-compose.yml`):**
   - Added `ENABLE_WIP_PAGES=true` to `app.environment` so WiP pages remain visible during local development while staying disabled by default in production.

## Verification
- Vitest suite: 100% pass (15 test files, 76 tests).
- Turbopack standalone production build: 100% pass.
- Verified in local Docker container with dynamic container restarts.

Closes #71
